### PR TITLE
External Secret

### DIFF
--- a/templates/jicofo-deployment.yaml
+++ b/templates/jicofo-deployment.yaml
@@ -45,17 +45,17 @@ spec:
           valueFrom:
             secretKeyRef:
               key: JICOFO_COMPONENT_SECRET
-              name: jitsi-config
+              name: jitsi-secrets
         - name: JICOFO_AUTH_USER
           value: focus
         - name: JICOFO_AUTH_PASSWORD
           valueFrom:
             secretKeyRef:
               key: JICOFO_AUTH_PASSWORD
-              name: jitsi-config
+              name: jitsi-secrets
         - name: TZ
           valueFrom:
-            secretKeyRef:
+            configMapKeyRef:
               key: TZ
               name: jitsi-config
         - name: JVB_BREWERY_MUC

--- a/templates/jvb-statefulset.yaml
+++ b/templates/jvb-statefulset.yaml
@@ -90,8 +90,6 @@ spec:
             secretKeyRef:
               key: JVB_STUN_SERVERS
               name: jitsi-config
-        - name: JICOFO_AUTH_USER
-          value: focus
         - name: JVB_TCP_HARVESTER_DISABLED
           value: "false"
         - name: COLIBRI_REST_ENABLED
@@ -102,11 +100,6 @@ spec:
           valueFrom:
             secretKeyRef:
               key: JVB_AUTH_PASSWORD
-              name: jitsi-config
-        - name: JICOFO_AUTH_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: JICOFO_AUTH_PASSWORD
               name: jitsi-config
         - name: JVB_BREWERY_MUC
           value: jvbbrewery

--- a/templates/jvb-statefulset.yaml
+++ b/templates/jvb-statefulset.yaml
@@ -87,7 +87,7 @@ spec:
           value: internal-muc.meet.jitsi
         - name: JVB_STUN_SERVERS
           valueFrom:
-            secretKeyRef:
+            configMapKeyRef:
               key: JVB_STUN_SERVERS
               name: jitsi-config
         - name: JVB_TCP_HARVESTER_DISABLED
@@ -100,17 +100,17 @@ spec:
           valueFrom:
             secretKeyRef:
               key: JVB_AUTH_PASSWORD
-              name: jitsi-config
+              name: jitsi-secrets
         - name: JVB_BREWERY_MUC
           value: jvbbrewery
         - name: TZ
           valueFrom:
-            secretKeyRef:
+            configMapKeyRef:
               key: TZ
               name: jitsi-config
         - name: PUBLIC_URL
           valueFrom:
-            secretKeyRef:
+            configMapKeyRef:
               name: jitsi-config
               key: PUBLIC_URL
         - name: JVB_WS_SERVER_ID

--- a/templates/prosody-deployment.yaml
+++ b/templates/prosody-deployment.yaml
@@ -103,25 +103,25 @@ spec:
             - name: JICOFO_COMPONENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: jitsi-config
+                  name: jitsi-secrets
                   key: JICOFO_COMPONENT_SECRET
             - name: JVB_AUTH_USER
               value: jvb
             - name: JVB_AUTH_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: jitsi-config
+                  name: jitsi-secrets
                   key: JVB_AUTH_PASSWORD
             - name: JICOFO_AUTH_USER
               value: focus
             - name: JICOFO_AUTH_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: jitsi-config
+                  name: jitsi-secrets
                   key: JICOFO_AUTH_PASSWORD
             - name: TZ
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: jitsi-config
                   key: TZ
             {{ if $.Values.prosody.monitoringEnable }}
@@ -143,7 +143,7 @@ spec:
             {{ end }}
             - name: PUBLIC_URL
               valueFrom:
-                secretKeyRef:
+                configMapKeyRef:
                   name: jitsi-config
                   key: PUBLIC_URL
           {{- if $.Values.prosody.extraEnvs }}

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 data:
-  JICOFO_AUTH_PASSWORD: {{ if $.Values.JICOFO_AUTH_PASSWORD }}{{ $.Values.JICOFO_AUTH_PASSWORD | b64enc }}{{ else }}{{ randAlphaNum 20 | b64enc }}{{ end }}
-  JICOFO_COMPONENT_SECRET: {{ if $.Values.JICOFO_COMPONENT_SECRET }}{{ $.Values.JICOFO_COMPONENT_SECRET | b64enc }}{{ else }}{{ randAlphaNum 20 | b64enc }}{{ end }}
-  JVB_AUTH_PASSWORD: {{ if $.Values.JVB_AUTH_PASSWORD }}{{ $.Values.JVB_AUTH_PASSWORD | b64enc }}{{ else }}{{ randAlphaNum 20 | b64enc }}{{ end }}
+  JICOFO_AUTH_PASSWORD: {{ required "JICOFO_AUTH_PASSWORD is required" $.Values.JICOFO_AUTH_PASSWORD | b64enc }}
+  JICOFO_COMPONENT_SECRET: {{ required "JICOFO_COMPONENT_SECRET is required" $.Values.JICOFO_COMPONENT_SECRET | b64enc }}
+  JVB_AUTH_PASSWORD: {{ required "JVB_AUTH_PASSWORD is required" $.Values.JVB_AUTH_PASSWORD | b64enc }}
 kind: Secret
 metadata:
   labels:

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -3,13 +3,10 @@ data:
   JICOFO_AUTH_PASSWORD: {{ if $.Values.JICOFO_AUTH_PASSWORD }}{{ $.Values.JICOFO_AUTH_PASSWORD | b64enc }}{{ else }}{{ randAlphaNum 20 | b64enc }}{{ end }}
   JICOFO_COMPONENT_SECRET: {{ if $.Values.JICOFO_COMPONENT_SECRET }}{{ $.Values.JICOFO_COMPONENT_SECRET | b64enc }}{{ else }}{{ randAlphaNum 20 | b64enc }}{{ end }}
   JVB_AUTH_PASSWORD: {{ if $.Values.JVB_AUTH_PASSWORD }}{{ $.Values.JVB_AUTH_PASSWORD | b64enc }}{{ else }}{{ randAlphaNum 20 | b64enc }}{{ end }}
-  JVB_STUN_SERVERS: {{ $.Values.JVB_STUN_SERVERS | b64enc }}
-  PUBLIC_URL: {{ if $.Values.PUBLIC_URL }}{{ $.Values.PUBLIC_URL | b64enc }}{{ else }}{{ if $.Values.haproxy.ingress.tlsEnable }}{{ print "https://" $.Values.haproxy.ingress.host | b64enc }}{{ else }}{{ print "http://" $.Values.haproxy.ingress.host | b64enc }}{{ end }}{{ end }}
-  TZ: {{ $.Values.TZ | b64enc }}
 kind: Secret
 metadata:
   labels:
     scope: jitsi
-  name: jitsi-config
+  name: jitsi-secrets
   namespace: {{ $.Values.namespace }}
 type: Opaque

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if $.Values.createSecret -}}
 apiVersion: v1
 data:
   JICOFO_AUTH_PASSWORD: {{ required "JICOFO_AUTH_PASSWORD is required" $.Values.JICOFO_AUTH_PASSWORD | b64enc }}
@@ -10,3 +11,4 @@ metadata:
   name: jitsi-secrets
   namespace: {{ $.Values.namespace }}
 type: Opaque
+{{- end }}

--- a/templates/shared-config.yaml
+++ b/templates/shared-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  JVB_STUN_SERVERS: {{ $.Values.JVB_STUN_SERVERS }}
+  PUBLIC_URL: {{ if $.Values.PUBLIC_URL }}{{ $.Values.PUBLIC_URL }}{{ else }}{{ if $.Values.haproxy.ingress.tlsEnable }}{{ print "https://" $.Values.haproxy.ingress.host }}{{ else }}{{ print "http://" $.Values.haproxy.ingress.host }}{{ end }}{{ end }}
+  TZ: {{ $.Values.TZ }}
+kind: ConfigMap
+metadata:
+  labels:
+    scope: jitsi
+  name: jitsi-config
+  namespace: {{ $.Values.namespace }}

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -53,12 +53,12 @@ spec:
           value: muc.meet.jitsi
         - name: TZ
           valueFrom:
-            secretKeyRef:
+            configMapKeyRef:
               key: TZ
               name: jitsi-config
         - name: PUBLIC_URL
           valueFrom:
-            secretKeyRef:
+            configMapKeyRef:
               name: jitsi-config
               key: PUBLIC_URL
       {{- if $.Values.web.extraEnvs }}

--- a/values.yaml
+++ b/values.yaml
@@ -79,6 +79,7 @@ web:
 # can be used to instantiate several Jitsi clusters on one Kubernetes cluster
 metacontrollerNamespace: metacontroller
 
+createSecret: true
 JICOFO_AUTH_PASSWORD: ""
 JICOFO_COMPONENT_SECRET: ""
 JVB_AUTH_PASSWORD: ""


### PR DESCRIPTION
* Don't generate a new secret value each time the helm is applied if (e.g.) Jicofo gets restarted by the deploy but Prosody doesn't then Jicofo can't auth
* Either:
  * Require all the secrets to be passed in
  * Or have the `jitsi-secret` pre-created - this is what our Terraform will do so that the values.yaml isn't marked as sensitive 