### PR TITLE
Shutdown API fixes 

### DIFF
--- a/configs/jvb/entrypoint.sh
+++ b/configs/jvb/entrypoint.sh
@@ -16,10 +16,6 @@ echo "JVB_PORT=$JVB_PORT"
 export JVB_TCP_PORT=$(($JVB_PORT+1))
 export JVB_TCP_MAPPED_PORT=$JVB_TCP_PORT
 
-echo "Allowing shutdown of JVB via Rest from localhost..."
-echo "org.jitsi.videobridge.ENABLE_REST_SHUTDOWN=true" >> /defaults/sip-communicator.properties
-echo "org.jitsi.videobridge.shutdown.ALLOWED_SOURCE_REGEXP=127.0.0.1" >> /defaults/sip-communicator.properties
-
 echo "org.ice4j.ice.harvest.DISABLE_AWS_HARVESTER=true" >> /defaults/sip-communicator.properties
 
 exec "$@"

--- a/templates/jvb-statefulset.yaml
+++ b/templates/jvb-statefulset.yaml
@@ -96,6 +96,8 @@ spec:
           value: "false"
         - name: COLIBRI_REST_ENABLED
           value: "true"
+        - name: SHUTDOWN_REST_ENABLED
+          value: "true"
         - name: JVB_AUTH_USER
           value: jvb
         - name: JVB_AUTH_PASSWORD

--- a/values.yaml
+++ b/values.yaml
@@ -16,7 +16,7 @@ haproxy:
     # albGroup: global
 jicofo:
   name: jicofo
-  image: jitsi/jicofo:stable-5963
+  image: jitsi/jicofo:stable-6826
   imagePullPolicy: Always
   resources:
     requests:
@@ -30,7 +30,7 @@ jvb:
   # you can use this variable to have several Jitsi cluster running on a cluster
   # specifying "31" will use ports 31XXX
   nodeportPrefix: "30"
-  image: jitsi/jvb:stable-5963
+  image: jitsi/jvb:stable-6826
   imagePullPolicy: Always
   monitoringEnable: true
   sysctlDaemonSetEnable: true
@@ -41,7 +41,7 @@ jvb:
   extraEnvs: []
 prosody:
   name: prosody
-  image: jitsi/prosody:stable-5963
+  image: jitsi/prosody:stable-6826
   imagePullPolicy: Always
   monitoringEnable: true
   resources:
@@ -55,7 +55,7 @@ prosody:
   globalConfig: []
 web:
   name: web
-  image: jitsi/web:stable-5963
+  image: jitsi/web:stable-6826
   imagePullPolicy: Always
   ## kubectl create configmap -n <namespace> custom-config --from-file=custom-config.js
   customConfig: false


### PR DESCRIPTION
https://github.com/jitsi/docker-jitsi-meet/pull/1142 allowed configuration of the shutdown API via the modern config. The old config property hasn't worked in since the docker images switched to the modern config file.

Updates the default image versions to the latest Jitsi as we're only ever targeting the latest Jitsi with this helm chart