### PR TITLE
Allow configuration of pod serviceaccount to support deployment in OpenShift

### DIFF
--- a/templates/haproxy-statefulset.yaml
+++ b/templates/haproxy-statefulset.yaml
@@ -19,6 +19,10 @@ spec:
     {{- with $.Values.haproxy.extraPodSpec }}
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    
+    {{- if $.Values.global.serviceAccount }}
+      serviceAccountName: {{ $.Values.global.serviceAccount }}
+    {{- end }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/templates/jicofo-deployment.yaml
+++ b/templates/jicofo-deployment.yaml
@@ -31,6 +31,9 @@ spec:
     {{- with $.Values.jicofo.extraPodSpec }}
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- if $.Values.global.serviceAccount }}
+      serviceAccountName: {{ $.Values.global.serviceAccount }}
+    {{- end }}
       containers:
       - env:
         - name: XMPP_SERVER

--- a/templates/metacontroller-rbac.yaml
+++ b/templates/metacontroller-rbac.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: metacontroller
+  name: {{ $.Values.global.metacontrollerServiceAccount | default "metacontroller" }}
   namespace: {{ $.Values.metacontrollerNamespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -23,7 +23,7 @@ metadata:
   name: metacontroller
 subjects:
 - kind: ServiceAccount
-  name: metacontroller
+  name: {{ $.Values.global.metacontrollerServiceAccount | default "metacontroller" }}
   namespace: {{ $.Values.metacontrollerNamespace }}
 roleRef:
   kind: ClusterRole

--- a/templates/metacontroller.yaml
+++ b/templates/metacontroller.yaml
@@ -18,7 +18,7 @@ spec:
       labels:
         app.kubernetes.io/name: metacontroller
     spec:
-      serviceAccountName: metacontroller
+      serviceAccountName: {{ $.Values.global.metacontrollerServiceAccount | default "metacontroller" }}
       containers:
       - name: metacontroller
         image: metacontrollerio/metacontroller:v1.5.8

--- a/templates/prosody-deployment.yaml
+++ b/templates/prosody-deployment.yaml
@@ -36,6 +36,9 @@ spec:
     {{- with $.Values.prosody.extraPodSpec }}
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- if $.Values.global.serviceAccount }}
+      serviceAccountName: {{ $.Values.global.serviceAccount }}
+    {{- end }}
       volumes:
         - name: prosody
           configMap:

--- a/templates/service-per-pod-deployment.yaml
+++ b/templates/service-per-pod-deployment.yaml
@@ -17,6 +17,9 @@ spec:
         k8s-app: jitsi-service-per-pod
         scope: jitsi
     spec:
+    {{- if $.Values.global.metacontrollerServiceAccount -}}
+      serviceAccountName: {{ $.Values.global.metacontrollerServiceAccount }}
+    {{- end }}
       containers:
       - name: hooks
         image: metacontroller/jsonnetd:0.1

--- a/templates/sysctl-jvb-daemonset.yaml
+++ b/templates/sysctl-jvb-daemonset.yaml
@@ -24,6 +24,9 @@ spec:
     {{- with $.Values.jvb.extraPodSpec }}
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- if $.Values.global.serviceAccount }}
+      serviceAccountName: {{ $.Values.global.serviceAccount }}
+    {{- end }}
       hostNetwork: yes
       containers:
       - name: sysctl-jvb

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -31,6 +31,10 @@ spec:
     {{- with $.Values.web.extraPodSpec }}
       {{- toYaml . | nindent 6 }}
     {{- end }}
+
+    {{- if $.Values.global.serviceAccount }}
+      serviceAccountName: {{ $.Values.global.serviceAccount }}
+    {{- end }}
       containers:
       - env:
         - name: DISABLE_HTTPS

--- a/values.yaml
+++ b/values.yaml
@@ -1,3 +1,11 @@
+global:
+  # Uncomment and set these if you need to use privileged
+  # service accounts for s6-overlay's UID/GID switching
+  # at initialization time
+
+  # serviceAccount: "default"
+  # metacontrollerServiceAccount: "metacontroller"
+
 shardCount: 1
 namespace: jitsi
 


### PR DESCRIPTION
Because of the way Jitsi containers are initialized using [s6-overlay](https://github.com/just-containers/s6-overlay), running the pods in environments with more strict handling of uid/gid (Openshift in this case) inside containers fails if the default service account doesn't grant the pods ability to set uid / gid.

These updates to the templates allow us to specify a service account at a global level to be used for pods in each deployment, as well as configure the service account for the metacontroller if necessary, though that may involve a little more work.