### PR TITLE
Various fixes

### DIFF
--- a/configs/haproxy/haproxy.cfg
+++ b/configs/haproxy/haproxy.cfg
@@ -56,3 +56,4 @@ backend jitsi-meet
   # _http._tcp.web.jitsi.svc.cluster.local:80 is a SRV DNS record
   # A records don't work here because their order might change between calls and would result in different
   # shard IDs for each peered HAproxy
+  server-template shard 0-{{ $.Values.shardCount }} _http._tcp.{{ $.Values.web.name }}.{{ $.Values.namespace}}.svc.cluster.local:80 check resolvers kube-dns init-addr none

--- a/configs/haproxy/haproxy.cfg
+++ b/configs/haproxy/haproxy.cfg
@@ -63,4 +63,4 @@ backend jitsi-meet
   # _http._tcp.web.jitsi.svc.cluster.local:80 is a SRV DNS record
   # A records don't work here because their order might change between calls and would result in different
   # shard IDs for each peered HAproxy
-  server-template shard 0-{{ $.Values.shardCount }} _http._tcp.{{ $.Values.web.name }}.{{ $.Values.namespace}}.svc.cluster.local:80 check resolvers kube-dns init-addr none
+  server-template shard 1-{{ $.Values.shardCount }} _http._tcp.{{ $.Values.web.name }}.{{ $.Values.namespace}}.svc.cluster.local:80 check resolvers kube-dns init-addr none

--- a/configs/haproxy/haproxy.cfg
+++ b/configs/haproxy/haproxy.cfg
@@ -38,9 +38,16 @@ frontend stats
   stats refresh 10s
 
 peers mypeers
+  bind :1024
   log stdout format raw local0 info
-  peer "${HOSTNAME}" "${MY_POD_IP}:1024"
-  peer "${OTHER_HOSTNAME}" "${OTHER_IP}:1024"
+
+.if streq("${HOSTNAME}",{{ $.Values.haproxy.name }}-0)
+  server {{ $.Values.haproxy.name }}-0
+  server {{ $.Values.haproxy.name }}-1 "{{ print "${" $.Values.haproxy.name | upper }}_1_SERVICE_HOST}:{{ print "${" $.Values.haproxy.name | upper }}_1_SERVICE_PORT}"
+.else
+  server {{ $.Values.haproxy.name }}-0 "{{ print "${" $.Values.haproxy.name | upper}}_0_SERVICE_HOST}:{{ print "${" $.Values.haproxy.name | upper }}_0_SERVICE_PORT}"
+  server {{ $.Values.haproxy.name }}-1
+.endif
 
 backend jitsi-meet
   balance roundrobin

--- a/templates/haproxy-config.yaml
+++ b/templates/haproxy-config.yaml
@@ -1,8 +1,7 @@
 apiVersion: v1
 data:
   haproxy.cfg: |
-    {{- .Files.Get "configs/haproxy/haproxy.cfg" | nindent 4 }}
-    server-template shard 0-{{ $.Values.shardCount }} _http._tcp.{{ $.Values.web.name }}.{{ $.Values.namespace}}.svc.cluster.local:80 check resolvers kube-dns init-addr none
+    {{ tpl (.Files.Get "configs/haproxy/haproxy.cfg") . | nindent 4 }}
 kind: ConfigMap
 metadata:
   name: haproxy-config

--- a/templates/haproxy-services.yaml
+++ b/templates/haproxy-services.yaml
@@ -22,6 +22,8 @@ spec:
   ports:
   - name: peering
     port: 1024
+  selector:
+   statefulset.kubernetes.io/pod-name: {{ $.Values.haproxy.name }}-0
   type: ClusterIP
 ---
 apiVersion: v1
@@ -33,4 +35,6 @@ spec:
   ports:
   - name: peering
     port: 1024
+  selector:
+   statefulset.kubernetes.io/pod-name: {{ $.Values.haproxy.name }}-1
   type: ClusterIP

--- a/templates/haproxy-statefulset.yaml
+++ b/templates/haproxy-statefulset.yaml
@@ -34,18 +34,7 @@ spec:
                 - {{ $.Values.haproxy.name }}
             topologyKey: topology.kubernetes.io/zone
       containers:
-      - args:
-        - > 
-          [[ $HOSTNAME = '{{ $.Values.haproxy.name }}-1' ]] 
-          && export OTHER_HOSTNAME={{ $.Values.haproxy.name }}-0 
-          OTHER_IP=$(getent hosts {{ $.Values.haproxy.name }}-0 | awk '{print $1}') 
-          || export OTHER_HOSTNAME={{ $.Values.haproxy.name }}-1 
-          OTHER_IP=$(getent hosts {{ $.Values.haproxy.name }}-1 | awk '{print $1}'); 
-          exec /docker-entrypoint.sh haproxy -f /usr/local/etc/haproxy/haproxy.cfg
-        command:
-        - bash
-        - -c
-        env:
+      - env:
         - name: MY_POD_IP
           valueFrom:
             fieldRef:

--- a/templates/haproxy-statefulset.yaml
+++ b/templates/haproxy-statefulset.yaml
@@ -20,8 +20,8 @@ spec:
       {{- toYaml . | nindent 6 }}
     {{- end }}
     
-    {{- if $.Values.global.serviceAccount }}
-      serviceAccountName: {{ $.Values.global.serviceAccount }}
+    {{- if (($.Values.global).serviceAccount) }}
+      serviceAccountName: {{ (($.Values.global).serviceAccount) }}
     {{- end }}
       affinity:
         podAntiAffinity:

--- a/templates/jicofo-deployment.yaml
+++ b/templates/jicofo-deployment.yaml
@@ -31,8 +31,8 @@ spec:
     {{- with $.Values.jicofo.extraPodSpec }}
       {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- if $.Values.global.serviceAccount }}
-      serviceAccountName: {{ $.Values.global.serviceAccount }}
+    {{- if (($.Values.global).serviceAccount) }}
+      serviceAccountName: {{ (($.Values.global).serviceAccount) }}
     {{- end }}
       containers:
       - env:

--- a/templates/metacontroller-rbac.yaml
+++ b/templates/metacontroller-rbac.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ $.Values.global.metacontrollerServiceAccount | default "metacontroller" }}
+  name: {{ (($.Values.global).metacontrollerServiceAccount) | default "metacontroller" }}
   namespace: {{ $.Values.metacontrollerNamespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -23,7 +23,7 @@ metadata:
   name: metacontroller
 subjects:
 - kind: ServiceAccount
-  name: {{ $.Values.global.metacontrollerServiceAccount | default "metacontroller" }}
+  name: {{ (($.Values.global).metacontrollerServiceAccount) | default "metacontroller" }}
   namespace: {{ $.Values.metacontrollerNamespace }}
 roleRef:
   kind: ClusterRole

--- a/templates/metacontroller.yaml
+++ b/templates/metacontroller.yaml
@@ -18,7 +18,7 @@ spec:
       labels:
         app.kubernetes.io/name: metacontroller
     spec:
-      serviceAccountName: {{ $.Values.global.metacontrollerServiceAccount | default "metacontroller" }}
+      serviceAccountName: {{ (($.Values.global).metacontrollerServiceAccount) | default "metacontroller" }}
       containers:
       - name: metacontroller
         image: metacontrollerio/metacontroller:v1.5.8

--- a/templates/prosody-deployment.yaml
+++ b/templates/prosody-deployment.yaml
@@ -36,8 +36,8 @@ spec:
     {{- with $.Values.prosody.extraPodSpec }}
       {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- if $.Values.global.serviceAccount }}
-      serviceAccountName: {{ $.Values.global.serviceAccount }}
+    {{- if (($.Values.global).serviceAccount) }}
+      serviceAccountName: {{ (($.Values.global).serviceAccount) }}
     {{- end }}
       volumes:
         - name: prosody

--- a/templates/service-per-pod-configmap.yaml
+++ b/templates/service-per-pod-configmap.yaml
@@ -27,7 +27,7 @@ data:
                              c for c in statefulset.spec.template.spec.containers
                              if c.name == 'jvb'
                            ][0].args
-                           if std.startsWith(a, '3') && std.length(a) == 5][0]),
+                           if std.length(a) == 5][0]),
 
       // create a service for each pod, with a selector on the given label key
       attachments: [

--- a/templates/service-per-pod-deployment.yaml
+++ b/templates/service-per-pod-deployment.yaml
@@ -17,8 +17,8 @@ spec:
         k8s-app: jitsi-service-per-pod
         scope: jitsi
     spec:
-    {{- if $.Values.global.metacontrollerServiceAccount -}}
-      serviceAccountName: {{ $.Values.global.metacontrollerServiceAccount }}
+    {{- if (($.Values.global).metacontrollerServiceAccount) -}}
+      serviceAccountName: {{ (($.Values.global).metacontrollerServiceAccount) }}
     {{- end }}
       containers:
       - name: hooks

--- a/templates/sysctl-jvb-daemonset.yaml
+++ b/templates/sysctl-jvb-daemonset.yaml
@@ -24,8 +24,8 @@ spec:
     {{- with $.Values.jvb.extraPodSpec }}
       {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- if $.Values.global.serviceAccount }}
-      serviceAccountName: {{ $.Values.global.serviceAccount }}
+    {{- if (($.Values.global).serviceAccount) }}
+      serviceAccountName: {{ (($.Values.global).serviceAccount) }}
     {{- end }}
       hostNetwork: yes
       containers:

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -32,8 +32,8 @@ spec:
       {{- toYaml . | nindent 6 }}
     {{- end }}
 
-    {{- if $.Values.global.serviceAccount }}
-      serviceAccountName: {{ $.Values.global.serviceAccount }}
+    {{- if (($.Values.global).serviceAccount) }}
+      serviceAccountName: {{ (($.Values.global).serviceAccount) }}
     {{- end }}
       containers:
       - env:

--- a/values.yaml
+++ b/values.yaml
@@ -14,7 +14,7 @@ namespace: jitsi
 
 haproxy:
   name: haproxy
-  image: haproxy:2.3
+  image: haproxy:2.4
   ingressEnable: true
   ingress:
     # can be alb


### PR DESCRIPTION
b60a988 brings in a required fix from the `openshift` branch

01f1156 is what was preventing peering from working
Before:
```
haproxy@haproxy-0:/$ exec 3<>/dev/tcp/127.0.0.1/9999 && echo "show peers" >&3 && cat <&3
0x5555c2ff9b20: [16/Mar/2022:12:29:52] id=mypeers disabled=0 flags=0x33 resync_timeout=<PAST> task_calls=707
  0x5555c30004a0: id=haproxy-1(remote,active) addr=10.100.85.136:1024 last_status=CONN last_hdshk=1s
        reconnect=3s heartbeat=<NEVER> confirm=0 tx_hbt=0 rx_hbt=0 no_hbt=0 new_conn=673 proto_err=0 coll=0
        flags=0x0 appctx:0x7f2ee4043f50 st0=6 st1=0 task_calls=1 state=TAR
        shared tables:
          0x5555c300c780 local_id=1 remote_id=0 flags=0x0 remote_data=0x0
              last_acked=0 last_pushed=0 last_get=0 teaching_origin=0 update=0
              table:0x5555c30038b0 id=jitsi-meet update=33 localupdate=33 commitupdate=0 refcnt=1
        Dictionary cache not dumped (use "show peers dict")
  0x5555c2ffa030: id=haproxy-0(local,inactive) addr=0.0.0.0:1024 last_status=NONE last_hdshk=<NEVER>
        reconnect=<NEVER> heartbeat=<NEVER> confirm=0 tx_hbt=0 rx_hbt=0 no_hbt=0 new_conn=0 proto_err=0 coll=0
        flags=0x0
        shared tables:
          0x5555c300c7d0 local_id=1 remote_id=0 flags=0x0 remote_data=0x0
              last_acked=0 last_pushed=0 last_get=0 teaching_origin=0 update=0
              table:0x5555c30038b0 id=jitsi-meet update=33 localupdate=33 commitupdate=0 refcnt=1
        Dictionary cache not dumped (use "show peers dict")
```
Notice `last_status=CONN`

After:
```
haproxy@haproxy-0:/$ exec 3<>/dev/tcp/127.0.0.1/9999 && echo "show peers" >&3 && cat <&3
0x55d045daab10: [16/Mar/2022:14:40:25] id=mypeers disabled=0 flags=0x6833 resync_timeout=<PAST> task_calls=72
  0x55d045db1490: id=haproxy-1(remote,active) addr=10.100.85.136:1024 last_status=ESTA last_hdshk=2m30s
        reconnect=4s heartbeat=0s confirm=0 tx_hbt=48 rx_hbt=50 no_hbt=0 new_conn=1 proto_err=0 coll=1
        flags=0x20000200 appctx:0x7f8de8037b10 st0=7 st1=0 task_calls=105 state=EST
        xprt=RAW src=172.20.125.125:40564 addr=172.20.57.71:1024
        remote_table:0x55d045dbc740 id=jitsi-meet local_id=1 remote_id=1
        last_local_table:0x55d045dbc740 id=jitsi-meet local_id=1 remote_id=1
        shared tables:
          0x55d045dbc740 local_id=1 remote_id=1 flags=0x0 remote_data=0x80001
              last_acked=0 last_pushed=3 last_get=0 teaching_origin=0 update=3
              table:0x55d045db48a0 id=jitsi-meet update=3 localupdate=3 commitupdate=3 refcnt=1
        Dictionary cache not dumped (use "show peers dict")
  0x55d045dab020: id=haproxy-0(local,inactive) addr=0.0.0.0:1024 last_status=NONE last_hdshk=<NEVER>
        reconnect=<NEVER> heartbeat=<NEVER> confirm=0 tx_hbt=0 rx_hbt=0 no_hbt=0 new_conn=0 proto_err=0 coll=0
        flags=0x0
        shared tables:
          0x55d045dbc790 local_id=1 remote_id=0 flags=0x0 remote_data=0x0
              last_acked=0 last_pushed=0 last_get=0 teaching_origin=0 update=0
              table:0x55d045db48a0 id=jitsi-meet update=3 localupdate=3 commitupdate=3 refcnt=1
        Dictionary cache not dumped (use "show peers dict")

```
Notice `last_status=ESTA`

910bf5f is because we've had requests to use `nodeportPrefix > 39`

The other commits are some tidyups so that haproxy config is all in one place, we don't have any funky entrypoint to the haproxy containers and so that we don't expect an extra shard when setting the shard count to 1.