### PR TITLE
JVB: allow construction of services without the metacontroller

### DIFF
--- a/templates/jvb-services.yaml
+++ b/templates/jvb-services.yaml
@@ -1,0 +1,52 @@
+{{ if eq $.Values.metacontrollerNamespace "" -}}
+{{- range $shard, $e := until (int $.Values.shardCount) }}
+{{- range $replica, $f := until (int $.Values.jvb.replicas) }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    scope: jitsi
+    service: jvb
+    shard: {{ $shard | quote }}
+    replica: {{ $replica | quote }}
+  name: shard-{{ $shard }}-{{ $.Values.jvb.name }}-{{ $replica }}-ice
+  namespace: {{ $.Values.namespace }}
+spec:
+  type: NodePort
+  externalTrafficPolicy: Local
+  ports:
+  - name: "jvb-udp"
+    protocol: "UDP"
+    port: {{ $.Values.jvb.nodeportPrefix }}{{ add $shard 3 }}{{ printf "%02d" $replica }}
+    targetPort: {{ $.Values.jvb.nodeportPrefix }}{{ add $shard 3 }}{{ printf "%02d" $replica }}
+    nodePort: {{ $.Values.jvb.nodeportPrefix }}{{ add $shard 3 }}{{ printf "%02d" $replica }}
+  selector:
+    statefulset.kubernetes.io/pod-name: shard-{{ $shard }}-{{ $.Values.jvb.name }}-{{ $replica }}
+    scope: jitsi
+    shard: {{ $shard | quote }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    scope: jitsi
+    service: jvb
+    shard: {{ $shard | quote }}
+    replica: {{ $replica | quote }}
+  name: shard-{{ $shard }}-{{ $.Values.jvb.name }}-{{ $replica }}-metrics
+  namespace: {{ $.Values.namespace }}
+spec:
+  type: ClusterIP
+  ports:
+  - name: "metrics"
+    protocol: "TCP"
+    port: 9888
+    targetPort: metrics
+  selector:
+    statefulset.kubernetes.io/pod-name: shard-{{ $shard }}-{{ $.Values.jvb.name }}-{{ $replica }}
+    scope: jitsi
+    shard: {{ $shard | quote }}
+{{ end -}}
+{{ end -}}
+{{ end -}}


### PR DESCRIPTION
The metacontroller can be a pain (extra RBAC, race-conditions on recreating the Helm chart, etc). If it isn't installed, construct the the services manually. Be warned, if you have multiple installations of the chart in the same cluster and one of them uses the metacontroller, Helm and the metacontroller will fight over creating the services

You can't flip-flop the chart between using the metacontroller and not. Helm requires labels and annotations to take ownership of resources:
```sh
kubectl -n metacontroller scale --replicas=0 statefulset.apps/metacontroller
kubectl -n <namespace> label svc shard-0-jvb-0-ice app.kubernetes.io/managed-by=Helm
kubectl -n <namespace> annotate svc shard-0-jvb-0-ice meta.helm.sh/release-name=jitsi
kubectl -n <namespace> annotate svc shard-0-jvb-0-ice meta.helm.sh/release-namespace=<namespace>
kubectl -n <namespace> label svc shard-0-jvb-0-metrics app.kubernetes.io/managed-by=Helm
kubectl -n <namespace> annotate svc shard-0-jvb-0-metrics meta.helm.sh/release-name=jitsi
kubectl -n <namespace> annotate svc shard-0-jvb-0-metrics meta.helm.sh/release-namespace=<namespace>
```

Corresponding `label` and `annotate` commands would be required to take ownership away from Helm again