### PR TITLE
JVB: support running with hostPort rather than nodePort

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The following table lists the configurable parameters of the Jitsi Meet chart an
 | `jvb.image.imagePullPolicy`        | JVB image pull policy                                   | `Always`          |
 | `jvb.replicas`                     | JVB replica count                                       | `1`               |
 | `jvb.monitoringEnable`             | JVB exporter container                                  | `true`            |
+| `jvb.hostPort`                     | JVB hostPort                                            | empty             |
 | `jvb.nodeportPrefix`               | JVB Node port prefix                                    | `30`              |
 | `jvb.extraEnvs`                    | JVB extra environment variables                         | `[]`              |
 | `prosody.name`                     | Prosody deployment name                                 | `jitsi/prosody`   |
@@ -93,4 +94,5 @@ The following table lists the configurable parameters of the Jitsi Meet chart an
 ## Running two jitsi instances inside the same cluster
 
 1. The second instance should be deployed with specific settings :
-  - `jvb.nodeportPrefix` should use a different value from `30` to avoid ports conflicts
+  - `jvb.nodeportPrefix` should use a different value from `30` to avoid ports conflicts or
+  - `jvb.hostPort` that's distinct from other installations

--- a/configs/jvb/entrypoint.sh
+++ b/configs/jvb/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -euo pipefail
-
+{{ if empty $.Values.jvb.hostPort }}
 # JVB baseport can be passed to this script
 if [[ "$1" =~ ^[0-9]+$ ]]; then
     BASE_PORT=$1
@@ -11,6 +11,9 @@ fi
 
 # add jvb ID to the base port (e.g. 30300 + 1 = 30301)
 export JVB_PORT=$(($BASE_PORT+${HOSTNAME##*-}))
+{{- else }}
+export JVB_PORT="{{ $.Values.jvb.hostPort }}"
+{{- end }}
 echo "JVB_PORT=$JVB_PORT"
 
 exec "$@"

--- a/templates/jvb-entrypoint.yaml
+++ b/templates/jvb-entrypoint.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   entrypoint.sh: |
-    {{- .Files.Get "configs/jvb/entrypoint.sh" | nindent 4 }}
+    {{- tpl (.Files.Get "configs/jvb/entrypoint.sh") . | nindent 4 }}
 kind: ConfigMap
 metadata:
   labels:

--- a/templates/jvb-services.yaml
+++ b/templates/jvb-services.yaml
@@ -1,5 +1,6 @@
 {{- range $shard, $e := until (int $.Values.shardCount) }}
 {{- range $replica, $f := until (int $.Values.jvb.replicas) }}
+{{ if empty $.Values.jvb.hostPort }}
 ---
 apiVersion: v1
 kind: Service
@@ -24,6 +25,7 @@ spec:
     statefulset.kubernetes.io/pod-name: shard-{{ $shard }}-{{ $.Values.jvb.name }}-{{ $replica }}
     scope: jitsi
     shard: {{ $shard | quote }}
+{{ end -}}
 ---
 apiVersion: v1
 kind: Service

--- a/templates/jvb-statefulset.yaml
+++ b/templates/jvb-statefulset.yaml
@@ -62,7 +62,9 @@ spec:
             memory: 100Mi
       {{ end -}}
       - args:
+      {{- if empty $.Values.jvb.hostPort }}
         - "{{ $.Values.jvb.nodeportPrefix }}{{ add $shard 3 }}00"
+      {{- end }}
         - /init
         command:
         - /entrypoint/entrypoint.sh
@@ -131,6 +133,12 @@ spec:
         ports:
         - containerPort: 9090
           name: websocket
+      {{- if not (empty $.Values.jvb.hostPort) }}
+        - containerPort: {{ $.Values.jvb.hostPort }}
+          name: ice
+          hostPort: {{ $.Values.jvb.hostPort }}
+          protocol: UDP
+      {{- end }}
         readinessProbe:
           httpGet:
             path: /about/health

--- a/values.yaml
+++ b/values.yaml
@@ -35,6 +35,7 @@ jicofo:
 jvb:
   name: jvb
   replicas: 2
+  # Specify hostPort to use hostPort and not nodePort
   # Nodeports 30XXX will be used by default
   # you can use this variable to have several Jitsi cluster running on a cluster
   # specifying "31" will use ports 31XXX


### PR DESCRIPTION
Set `jvb.hostPort` to use `hostPort`s rather than `nodePort`. If unset then will use `nodePort` as before