### PR TITLE
Support running multiple web replicas

### DIFF
--- a/configs/haproxy/haproxy.cfg
+++ b/configs/haproxy/haproxy.cfg
@@ -53,6 +53,8 @@ backend jitsi-meet
   balance roundrobin
   mode http
   option forwardfor
+  option httpchk
+  http-check send meth GET hdr User-Agent haproxy
   compression algo gzip
   compression type text/html text/plain text/css text/javascript application/wasm
   http-reuse safe
@@ -60,7 +62,9 @@ backend jitsi-meet
   acl room_found urlp(room) -m found
   stick-table type string len 128 size 2k expire 1d peers mypeers
   stick on hdr(Room) if room_found
-  # _http._tcp.web.jitsi.svc.cluster.local:80 is a SRV DNS record
-  # A records don't work here because their order might change between calls and would result in different
-  # shard IDs for each peered HAproxy
-  server-template shard 1-{{ $.Values.shardCount }} _http._tcp.{{ $.Values.web.name }}.{{ $.Values.namespace}}.svc.cluster.local:80 check resolvers kube-dns init-addr none
+
+  # We don't use server-template here so as we want to use k8s to dispatch to an up nginx in the shard
+  # If we used server-template we'd have web.replicas * shardCount nginxes
+{{- range $shard, $e := until (int $.Values.shardCount) }}
+  server shard{{ $shard }} shard-{{ $shard }}-{{ $.Values.web.name }}.{{ $.Values.namespace}}.svc.cluster.local:80 check resolvers kube-dns init-addr none
+{{- end }}

--- a/templates/haproxy-statefulset.yaml
+++ b/templates/haproxy-statefulset.yaml
@@ -15,6 +15,8 @@ spec:
     metadata:
       labels:
         k8s-app: {{ $.Values.haproxy.name }}
+      annotations:
+        checksum/config: {{ tpl (.Files.Get "configs/haproxy/haproxy.cfg") . | sha256sum }}
     spec:
     {{- with $.Values.haproxy.extraPodSpec }}
       {{- toYaml . | nindent 6 }}

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
   name: shard-{{ $shard }}-{{ $.Values.web.name }}
   namespace: {{ $.Values.namespace }}
 spec:
-  replicas: 1
+  replicas: {{ $.Values.web.replicas }}
   selector:
     matchLabels:
       k8s-app: {{ $.Values.web.name }}

--- a/templates/web-service.yaml
+++ b/templates/web-service.yaml
@@ -1,13 +1,15 @@
+{{- range $shard, $e := until (int $.Values.shardCount) }}
+---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
     scope: jitsi
     service: {{ $.Values.web.name }}
-  name: {{ $.Values.web.name }}
+    shard: {{ $shard | quote}}
+  name: shard-{{ $shard }}-{{ $.Values.web.name }}
   namespace: {{ $.Values.namespace }}
 spec:
-  clusterIP: None
   ports:
   - name: http
     port: 80
@@ -15,3 +17,5 @@ spec:
   selector:
     k8s-app: {{ $.Values.web.name }}
     scope: jitsi
+    shard: {{ $shard | quote}}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -8,9 +8,6 @@ global:
 shardCount: 1
 namespace: jitsi
 
-# extraPodSpec can be used to add tolerations and placement hints
-# to any of the following components
-
 haproxy:
   name: haproxy
   image: haproxy:2.4
@@ -23,6 +20,7 @@ haproxy:
     # albGroup: global
   certmanager:
     issuer: letsencrypt-prod
+  extraPodSpec: {}
 jicofo:
   name: jicofo
   image: jitsi/jicofo:stable-7648-2
@@ -32,6 +30,7 @@ jicofo:
       cpu: 400m
       memory: 400Mi
   extraEnvs: []
+  extraPodSpec: {}
 jvb:
   name: jvb
   replicas: 2
@@ -49,6 +48,7 @@ jvb:
       cpu: 3000m
       memory: 3000Mi
   extraEnvs: []
+  extraPodSpec: {}
 prosody:
   name: prosody
   image: jitsi/prosody:stable-7648-2
@@ -59,6 +59,7 @@ prosody:
       memory: 300Mi
       cpu: 300m
   extraEnvs: []
+  extraPodSpec: {}
   extraVolumes: []
   extraVolumeMounts: []
   globalModules: []
@@ -83,6 +84,7 @@ web:
       cpu: 400m
       memory: 300Mi
   extraEnvs: []
+  extraPodSpec: {}
   extraVolumes: []
   extraVolumeMounts: []
 

--- a/values.yaml
+++ b/values.yaml
@@ -65,6 +65,7 @@ prosody:
   globalConfig: []
 web:
   name: web
+  replicas: 2
   image: jitsi/web:stable-7648-2
   imagePullPolicy: Always
   ## kubectl create configmap -n <namespace> custom-config --from-file=custom-config.js


### PR DESCRIPTION
This is a stateless pod, there's no reason it shouldn't be HA.

It does requires HAProxy changes as previously:
* There was a single nginx service with all nginxes behind it (1 per shard)
* `server-template` meant that we'd have a server per shard
* Adding extra nginxes would break that link

Have Helm construct a server per shard and let k8s route to an available nginx