### PR TITLE
Dont advertise private candidates

### DIFF
--- a/templates/jvb-statefulset.yaml
+++ b/templates/jvb-statefulset.yaml
@@ -117,6 +117,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: JVB_ADVERTISE_PRIVATE_CANDIDATES
+          value: "false"
       {{- if $.Values.jvb.extraEnvs }}
         {{- toYaml $.Values.jvb.extraEnvs | nindent 8 }}
       {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -23,7 +23,7 @@ haproxy:
   extraPodSpec: {}
 jicofo:
   name: jicofo
-  image: jitsi/jicofo:stable-7648-2
+  image: jitsi/jicofo:stable-7648-3
   imagePullPolicy: Always
   resources:
     requests:
@@ -39,7 +39,9 @@ jvb:
   # you can use this variable to have several Jitsi cluster running on a cluster
   # specifying "31" will use ports 31XXX
   nodeportPrefix: "30"
-  image: jitsi/jvb:stable-7648-2
+  # For https://github.com/jitsi/docker-jitsi-meet/pull/1379
+  # This can go back to upstream in the next Jitsi release as it has been merged
+  image: ghcr.io/matrix-org/docker-jitsi-meet/jvb:stable-7648-3-ems.1
   imagePullPolicy: Always
   monitoringEnable: true
   sysctlDaemonSetEnable: true
@@ -51,7 +53,7 @@ jvb:
   extraPodSpec: {}
 prosody:
   name: prosody
-  image: jitsi/prosody:stable-7648-2
+  image: jitsi/prosody:stable-7648-3
   imagePullPolicy: Always
   monitoringEnable: true
   resources:
@@ -67,7 +69,7 @@ prosody:
 web:
   name: web
   replicas: 2
-  image: jitsi/web:stable-7648-2
+  image: jitsi/web:stable-7648-3
   imagePullPolicy: Always
   ## kubectl create configmap -n <namespace> custom-config --from-file=custom-config.js
   customConfig: false


### PR DESCRIPTION
Let the JVB know that it shouldn't advertise the pod IP to users, it will never be routable