### PR TITLE
Configure whether docker ip is set

### DIFF
--- a/templates/jvb-statefulset.yaml
+++ b/templates/jvb-statefulset.yaml
@@ -75,10 +75,12 @@ spec:
               fieldPath: metadata.name
         - name: XMPP_SERVER
           value: shard-{{ $shard }}-{{ $.Values.prosody.name }}.{{ $.Values.namespace }}.svc.cluster.local
+      {{- if $.Values.jvb.provideNodeAddressAsPublicIP }}
         - name: DOCKER_HOST_ADDRESS
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+      {{- end }}
         - name: XMPP_DOMAIN
           value: meet.jitsi
         - name: XMPP_AUTH_DOMAIN

--- a/values.yaml
+++ b/values.yaml
@@ -45,6 +45,10 @@ jvb:
   imagePullPolicy: Always
   monitoringEnable: true
   sysctlDaemonSetEnable: true
+  # In most k8s environments this will be a private IP and in most deployments, users will connect to a public ip
+  # so this won't provide a usable IP for users to connect to.
+  # Will rely on STUN providing the correct public IP if set to false.
+  provideNodeAddressAsPublicIP: false
   resources:
     requests:
       cpu: 3000m


### PR DESCRIPTION
`status.hostIP` generally (always?) returns the node private IP and not the public IP. As such unless the user can directly connect to that node private IP it isn't useful to consider as the JVB's "public" IP.

Default to relying on STUN to obtain the JVB public IP.

https://github.com/kubernetes/kubernetes/issues/73760 would provide any node public IP