### PR TITLE
Improve ports definitions and probes

### DIFF
--- a/templates/haproxy-services.yaml
+++ b/templates/haproxy-services.yaml
@@ -7,8 +7,10 @@ spec:
   ports:
   - name: http
     port: 8080
+    targetPort: http
   - name: metrics
     port: 9090
+    targetPort: metrics
   selector:
     k8s-app: {{ $.Values.haproxy.name }}
   type: ClusterIP
@@ -22,6 +24,7 @@ spec:
   ports:
   - name: peering
     port: 1024
+    targetPort: peering
   selector:
    statefulset.kubernetes.io/pod-name: {{ $.Values.haproxy.name }}-0
   type: ClusterIP
@@ -35,6 +38,7 @@ spec:
   ports:
   - name: peering
     port: 1024
+    targetPort: peering
   selector:
    statefulset.kubernetes.io/pod-name: {{ $.Values.haproxy.name }}-1
   type: ClusterIP

--- a/templates/haproxy-statefulset.yaml
+++ b/templates/haproxy-statefulset.yaml
@@ -50,6 +50,14 @@ spec:
           name: metrics
         - containerPort: 1024
           name: peering
+        readinessProbe:
+          httpGet:
+            path: /stats
+            port: metrics
+        startupProbe:
+          httpGet:
+            path: /stats
+            port: metrics
         volumeMounts:
         - mountPath: /usr/local/etc/haproxy/haproxy.cfg
           name: haproxy-config

--- a/templates/jicofo-deployment.yaml
+++ b/templates/jicofo-deployment.yaml
@@ -71,6 +71,10 @@ spec:
         image: {{ $.Values.jicofo.image }}
         imagePullPolicy: {{ $.Values.jicofo.imagePullPolicy }}
         name: jicofo
+        ports:
+        - containerPort: 8888
+          protocol: TCP
+          name: rest
         # readinessProbe:
         #   httpGet:
         #     path: /about/health

--- a/templates/jicofo-deployment.yaml
+++ b/templates/jicofo-deployment.yaml
@@ -78,7 +78,7 @@ spec:
         # readinessProbe:
         #   httpGet:
         #     path: /about/health
-        #     port: 8888
+        #     port: rest
       {{- with $.Values.jicofo.resources }}
         resources:
           {{- toYaml . | nindent 10 }}

--- a/templates/jicofo-deployment.yaml
+++ b/templates/jicofo-deployment.yaml
@@ -64,7 +64,7 @@ spec:
         - name: JVB_BREWERY_MUC
           value: jvbbrewery
         - name: JICOFO_ENABLE_HEALTH_CHECKS
-          value: "false"
+          value: "true"
       {{- if $.Values.jicofo.extraEnvs }}
         {{- toYaml $.Values.jicofo.extraEnvs | nindent 8 }}
       {{- end }}
@@ -75,10 +75,16 @@ spec:
         - containerPort: 8888
           protocol: TCP
           name: rest
-        # readinessProbe:
-        #   httpGet:
-        #     path: /about/health
-        #     port: rest
+        # We don't use /about/health for these probes as that queries whether the JVBs are active
+        # We don't want to restart Jicofo just because there are no JVBs
+        livenessProbe:
+           httpGet:
+             path: /about/version
+             port: rest
+        startupProbe:
+          httpGet:
+            path: /about/version
+            port: rest
       {{- with $.Values.jicofo.resources }}
         resources:
           {{- toYaml . | nindent 10 }}

--- a/templates/jvb-statefulset.yaml
+++ b/templates/jvb-statefulset.yaml
@@ -43,7 +43,7 @@ spec:
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
-            port: 9888
+            port: metrics
             path: "/health"
         name: prometheus-exporter
         ports:
@@ -51,7 +51,7 @@ spec:
           name: metrics
         readinessProbe:
           httpGet:
-            port: 9888
+            port: metrics
             path: "/health"
         resources:
           limits:
@@ -147,7 +147,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /about/health
-            port: 8080
+            port: private-http
           initialDelaySeconds: 10
       {{- with $.Values.jvb.resources }}
         resources:

--- a/templates/jvb-statefulset.yaml
+++ b/templates/jvb-statefulset.yaml
@@ -148,7 +148,10 @@ spec:
           httpGet:
             path: /about/health
             port: private-http
-          initialDelaySeconds: 10
+        startupProbe:
+          httpGet:
+            path: /about/health
+            port: private-http
       {{- with $.Values.jvb.resources }}
         resources:
           {{- toYaml . | nindent 10 }}

--- a/templates/jvb-statefulset.yaml
+++ b/templates/jvb-statefulset.yaml
@@ -134,7 +134,10 @@ spec:
         name: jvb
         ports:
         - containerPort: 9090
-          name: websocket
+          name: public-http
+        - containerPort: 8080
+          name: private-http
+          protocol: TCP
       {{- if not (empty $.Values.jvb.hostPort) }}
         - containerPort: {{ $.Values.jvb.hostPort }}
           name: ice

--- a/templates/prosody-deployment.yaml
+++ b/templates/prosody-deployment.yaml
@@ -63,8 +63,12 @@ spec:
           imagePullPolicy: {{ $.Values.prosody.imagePullPolicy }}
           {{ if $.Values.prosody.monitoringEnable -}}
           ports:
-            - name: metrics
-              containerPort: 5280
+          - containerPort: 5280
+            protocol: TCP
+            name: http
+          - containerPort: 5222
+            protocol: TCP
+            name: c2s
           {{ end -}}
           readinessProbe:
             ## the command that is called obeys standard exit codes

--- a/templates/prosody-deployment.yaml
+++ b/templates/prosody-deployment.yaml
@@ -78,6 +78,14 @@ spec:
                 - --config
                 - /config/prosody.cfg.lua
                 - status
+          startupProbe:
+            ## the command that is called obeys standard exit codes
+            exec:
+              command:
+                - prosodyctl
+                - --config
+                - /config/prosody.cfg.lua
+                - status
           volumeMounts:
           {{ if $.Values.prosody.monitoringEnable -}}
           # add-ons that allow exporting of metrics to prometheus (mod_prometheus.lua)

--- a/templates/prosody-svc.yaml
+++ b/templates/prosody-svc.yaml
@@ -11,12 +11,12 @@ metadata:
   namespace: {{ $.Values.namespace }}
 spec:
   ports:
-  - name: "5222"
+  - name: c2s
     port: 5222
-    targetPort: 5222
-  - name: "5280"
+    targetPort: c2s
+  - name: http
     port: 5280
-    targetPort: 5280
+    targetPort: http
   selector:
     k8s-app: {{ $.Values.prosody.name }}
     scope: jitsi

--- a/templates/prosody-svc.yaml
+++ b/templates/prosody-svc.yaml
@@ -17,9 +17,6 @@ spec:
   - name: "5280"
     port: 5280
     targetPort: 5280
-  - name: "5347"
-    port: 5347
-    targetPort: 5347
   selector:
     k8s-app: {{ $.Values.prosody.name }}
     scope: jitsi

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -77,6 +77,11 @@ spec:
           name: http
         readinessProbe:
           httpGet:
+            path: /robots.txt
+            port: http
+        startupProbe:
+          httpGet:
+            path: /robots.txt
             port: http
       {{- with $.Values.web.resources }}
         resources:

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -77,7 +77,7 @@ spec:
           name: http
         readinessProbe:
           httpGet:
-            port: 80
+            port: http
       {{- with $.Values.web.resources }}
         resources:
           {{- toYaml . | nindent 10 }}

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -71,6 +71,10 @@ spec:
         image: {{ $.Values.web.image }}
         imagePullPolicy: {{ $.Values.web.imagePullPolicy }}
         name: web
+        ports:
+        - containerPort: 80
+          protocol: TCP
+          name: http
         readinessProbe:
           httpGet:
             port: 80

--- a/templates/web-service.yaml
+++ b/templates/web-service.yaml
@@ -13,7 +13,7 @@ spec:
   ports:
   - name: http
     port: 80
-    targetPort: 80
+    targetPort: http
   selector:
     k8s-app: {{ $.Values.web.name }}
     scope: jitsi


### PR DESCRIPTION
Use named ports whereever possible to avoid magic numbers.

Improve the probing situation so we kill dead pods as much as possible and use startupProbes as per best practices