### PR TITLE
Fix up ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,11 @@ The following table lists the configurable parameters of the Jitsi Meet chart an
 | `namespace`                        | Namespace                                               | `jitsi`           |
 | `haproxy.name`                     | Haproxy statefulset name                                | `jitsi/jicofo`    |
 | `haproxy.image`                    | Docker image                                            | `haproxy:2.1`     |
-| `haproxy.ingressEnable`            | Enable ingress                                          | `true`            |
-| `haproxy.ingress.host`             | Ingress host                                            | `jitsi.domain.org`|
-| `haproxy.ingress.tlsEnable`        | Enable TLS for ingress                                  | `true`            |
+| `ingress.enabled`                  | Enable ingress                                          | `true`            |
+| `ingress.hosts`                    | List of hosts in this ingress                           | empty             |
+| `ingress.class  `                  | Which ingressClassName to use                           | empty             |
+| `ingress.tls.enabled`              | Enable TLS for ingress                                  | `true`            |
+| `ingress.tls.secretName`           | Name of the secret storing the TLS certificate and key  | `jitsi-tls`       |
 | `jicofo.name`                      | Jicofo deployment name                                  | `jicofo`          |
 | `jicofo.image`                     | Jicofo docker image                                     | `jitsi/jicofo`    |
 | `jicofo.imagePullPolicy`           | Jicofo image pull policy                                | `Always`          |

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The following table lists the configurable parameters of the Jitsi Meet chart an
 | `ingress.class  `                  | Which ingressClassName to use                           | empty             |
 | `ingress.tls.enabled`              | Enable TLS for ingress                                  | `true`            |
 | `ingress.tls.secretName`           | Name of the secret storing the TLS certificate and key  | `jitsi-tls`       |
+| `ingress.extraPaths    `           | Extra paths to add to the ingress                       | `[]`              |
 | `jicofo.name`                      | Jicofo deployment name                                  | `jicofo`          |
 | `jicofo.image`                     | Jicofo docker image                                     | `jitsi/jicofo`    |
 | `jicofo.imagePullPolicy`           | Jicofo image pull policy                                | `Always`          |

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,72 +1,42 @@
-{{ if $.Values.haproxy.ingressEnable -}}
-{{ if eq $.Values.haproxy.ingress.class "alb" -}}
-apiVersion: networking.k8s.io/v1beta1
-kind: Ingress
-metadata:
-  name: ingress
-  namespace: {{ $.Values.namespace }}
-  annotations:
-    alb.ingress.kubernetes.io/group.name: {{ $.Values.haproxy.ingress.albGroup }}
-    kubernetes.io/ingress.class: alb
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/target-type: ip
-    {{ if $.Values.haproxy.ingress.tlsEnable }}
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
-    alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
-    {{ else }}
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
-    {{ end }}
-
-  labels:
-    scope: jitsi
-
-spec:
-  rules:
-  - host: {{ $.Values.haproxy.ingress.host }}
-    http:
-      paths:
-      {{ if $.Values.haproxy.ingress.tlsEnable -}}
-      - path: /*
-        backend:
-          serviceName: ssl-redirect
-          servicePort: use-annotation
-      {{ end -}}
-      - path: /*
-        backend:
-          serviceName: haproxy
-          servicePort: 8080
-{{ else -}}
+{{ if .Values.ingress.enabled -}}
+{{ $hosts := (gt (len $.Values.ingress.hosts) 0) | ternary ($.Values.ingress.hosts) (list ($.Values.PUBLIC_URL | default "" | replace "https://" "")) -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    {{- if $.Values.haproxy.certmanager.issuer }}
-    cert-manager.io/cluster-issuer: {{ $.Values.haproxy.certmanager.issuer }}
+    {{- if $.Values.ingress.tls.certManagerClusterIssuer }}
+    cert-manager.io/cluster-issuer: {{ $.Values.ingress.tls.certManagerClusterIssuer }}
     {{- end }}
-    kubernetes.io/ingress.class: {{ $.Values.haproxy.ingress.class }}
+    {{- if $.Values.ingress.annotations }}
+    {{- $.Values.ingress.annotations | toYaml | nindent 4 }}
+    {{- end }}
   name: ingress
   namespace: {{ $.Values.namespace }}
-
   labels:
     scope: jitsi
-
 spec:
+  {{ if $.Values.ingress.class -}}
+  ingressClassName: {{ $.Values.ingress.class }}
+  {{ end -}}
   rules:
-  - host: {{ $.Values.haproxy.ingress.host }}
+  {{ range $hosts -}}
+  - host: {{ . | quote }}
     http:
       paths:
       - backend:
           service:
             name: haproxy
             port:
-              number: 8080
+              name: http
         path: /
         pathType: Prefix
-  {{ if $.Values.haproxy.ingress.tlsEnable -}}
+  {{ end -}}
+  {{ if $.Values.ingress.tls.enabled -}}
   tls:
   - hosts:
-    - {{ $.Values.haproxy.ingress.host }}
-    secretName: jitsi-tls
+    {{ range $hosts -}}
+    - {{ . | quote }}
+    {{ end -}}
+    secretName: {{ $.Values.ingress.tls.secretName | quote }}
   {{ end -}}
-{{ end -}}
 {{ end -}}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -23,6 +23,19 @@ spec:
   - host: {{ . | quote }}
     http:
       paths:
+      {{ range $.Values.ingress.extraPaths -}}
+      - backend:
+          service:
+            name: {{ .serviceName | required "serviceName is required for every ingress.extraPaths" | quote }}
+            port:
+            {{- if .portName }}
+              name: {{ .portName | quote -}}
+            {{- else }}
+              number: {{ .portNumber | required "Either portName or portNumber is required for every ingress.extraPaths" -}}
+            {{ end }}
+        path: {{ .path | required "path is required for every ingress.extraPaths" | quote }}
+        pathType: {{ .pathType | default "Prefix" | quote }}
+      {{ end -}}
       - backend:
           service:
             name: haproxy

--- a/templates/shared-config.yaml
+++ b/templates/shared-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   JVB_STUN_SERVERS: {{ $.Values.JVB_STUN_SERVERS }}
-  PUBLIC_URL: {{ if $.Values.PUBLIC_URL }}{{ $.Values.PUBLIC_URL }}{{ else }}{{ if $.Values.haproxy.ingress.tlsEnable }}{{ print "https://" $.Values.haproxy.ingress.host }}{{ else }}{{ print "http://" $.Values.haproxy.ingress.host }}{{ end }}{{ end }}
+  PUBLIC_URL: {{ ((gt (len $.Values.ingress.hosts) 0) | ternary (print "https://" ($.Values.ingress.hosts | first)) $.Values.PUBLIC_URL) | required "One of PUBLIC_URL or ingress.hosts must be provided" }}
   TZ: {{ $.Values.TZ }}
 kind: ConfigMap
 metadata:

--- a/values.yaml
+++ b/values.yaml
@@ -17,6 +17,7 @@ ingress:
     secretName: jitsi-tls
     # certManagerClusterIssuer
   annotations: {}
+  extraPaths: []
 
 haproxy:
   name: haproxy

--- a/values.yaml
+++ b/values.yaml
@@ -8,18 +8,19 @@ global:
 shardCount: 1
 namespace: jitsi
 
+ingress:
+  enabled: true
+  hosts: []
+  # class:
+  tls:
+    enabled: true
+    secretName: jitsi-tls
+    # certManagerClusterIssuer
+  annotations: {}
+
 haproxy:
   name: haproxy
   image: haproxy:2.4
-  ingressEnable: true
-  ingress:
-    # can be alb
-    class: haproxy
-    host: jitsi.example.org
-    tlsEnable: true
-    # albGroup: global
-  certmanager:
-    issuer: letsencrypt-prod
   extraPodSpec: {}
 jicofo:
   name: jicofo


### PR DESCRIPTION
The prior version of the ingress template was a mess:
* Different versions of the Ingress resource were used
* Lots of special casing for the ALB
* Didn't support multiple hosts
* Didn't support adding annotations

The rationale for moving the settings out of the `haproxy` block is that I want to skip spinning up the HAProxy for single shard instances and go directly to the Jitsi Web pods

Tested with the following:
```sh
helm template -s templates/ingress.yaml --set 'ingress.hosts[0]=a.b' --set 'ingress.annotations.test\.ing=b' --set JICOFO_AUTH_PASSWORD=a --set JICOFO_COMPONENT_SECRET=b --set JVB_AUTH_PASSWORD=c --set 'ingress.extraPaths[0].serviceName=redirect-ssl' --set 'ingress.extraPaths[0].path=/' --set 'ingress.extraPaths[0].portName=something' . 
---
# Source: jitsi/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    test.ing: b
  name: ingress
  namespace: jitsi
  labels:
    scope: jitsi
spec:
  rules:
  - host: "a.b"
    http:
      paths:
      - backend:
          service:
            name: "redirect-ssl"
            port:
              name: "something"
        path: "/"
        pathType: "Prefix"
      - backend:
          service:
            name: haproxy
            port:
              name: http
        path: /
        pathType: Prefix
  tls:
  - hosts:
    - "a.b"
    secretName: "jitsi-tls"

$ helm template -s templates/ingress.yaml --set "PUBLIC_URL=https://a.b" --set JICOFO_AUTH_PASSWORD=a --set JICOFO_COMPONENT_SECRET=b --set JVB_AUTH_PASSWORD=c .
---
# Source: jitsi/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
  name: ingress
  namespace: jitsi
  labels:
    scope: jitsi
spec:
  rules:
  - host: "a.b"
    http:
      paths:
      - backend:
          service:
            name: haproxy
            port:
              name: http
        path: /
        pathType: Prefix
  tls:
  - hosts:
    - "a.b"
    secretName: "jitsi-tls"

$ helm template -s templates/ingress.yaml --set "PUBLIC_URL=https://a.b" --set JICOFO_AUTH_PASSWORD=a --set JICOFO_COMPONENT_SECRET=b --set JVB_AUTH_PASSWORD=c --set ingress.tls.enabled=false .
---
# Source: jitsi/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
  name: ingress
  namespace: jitsi
  labels:
    scope: jitsi
spec:
  rules:
  - host: "a.b"
    http:
      paths:
      - backend:
          service:
            name: haproxy
            port:
              name: http
        path: /
        pathType: Prefix
```

and 

```sh
$ helm template -s templates/shared-config.yaml --set "PUBLIC_URL=https://a.b" --set JICOFO_AUTH_PASSWORD=a --set JICOFO_COMPONENT_SECRET=b --set JVB_AUTH_PASSWORD=c .
---
# Source: jitsi/templates/shared-config.yaml
apiVersion: v1
data:
  JVB_STUN_SERVERS: stun.l.google.com:19302,stun1.l.google.com:19302,stun2.l.google.com:19302
  PUBLIC_URL: https://a.b
  TZ: Europe/London
kind: ConfigMap
metadata:
  labels:
    scope: jitsi
  name: jitsi-config
  namespace: jitsi

$ helm template -s templates/shared-config.yaml --set "ingress.hosts[0]=a.b" --set JICOFO_AUTH_PASSWORD=a --set JICOFO_COMPONENT_SECRET=b --set JVB_AUTH_PASSWORD=c .
---
# Source: jitsi/templates/shared-config.yaml
apiVersion: v1
data:
  JVB_STUN_SERVERS: stun.l.google.com:19302,stun1.l.google.com:19302,stun2.l.google.com:19302
  PUBLIC_URL: https://a.b
  TZ: Europe/London
kind: ConfigMap
metadata:
  labels:
    scope: jitsi
  name: jitsi-config
  namespace: jitsi
```