### PR TITLE
Dont create haproxy for single shard

### DIFF
--- a/templates/haproxy-config.yaml
+++ b/templates/haproxy-config.yaml
@@ -1,3 +1,4 @@
+{{ if (gt ($.Values.shardCount | int) 1) -}}
 apiVersion: v1
 data:
   haproxy.cfg: |
@@ -6,3 +7,4 @@ kind: ConfigMap
 metadata:
   name: haproxy-config
   namespace: {{ $.Values.namespace }}
+{{ end -}}

--- a/templates/haproxy-services.yaml
+++ b/templates/haproxy-services.yaml
@@ -1,3 +1,4 @@
+{{ if (gt ($.Values.shardCount | int) 1) -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -42,3 +43,4 @@ spec:
   selector:
    statefulset.kubernetes.io/pod-name: {{ $.Values.haproxy.name }}-1
   type: ClusterIP
+{{ end -}}

--- a/templates/haproxy-statefulset.yaml
+++ b/templates/haproxy-statefulset.yaml
@@ -1,3 +1,4 @@
+{{ if (gt ($.Values.shardCount | int) 1) -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -73,3 +74,4 @@ spec:
             path: haproxy.cfg
           name: haproxy-config
         name: haproxy-config
+{{ end -}}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -38,7 +38,7 @@ spec:
       {{ end -}}
       - backend:
           service:
-            name: haproxy
+            name: {{ if (gt ($.Values.shardCount | int) 1) }}haproxy{{ else }}shard-0-{{ $.Values.web.name }}{{ end }}
             port:
               name: http
         path: /


### PR DESCRIPTION
The HAProxy is only useful for sharded deploys. When running with just a single shard, we don't need it.

Tested with:
```sh
$ helm template -s templates/ingress.yaml --set "ingress.hosts[0]=a.b" --set JICOFO_AUTH_PASSWORD=a --set JICOFO_COMPONENT_SECRET=b --set JVB_AUTH_PASSWORD=c --debug --set shardCount=2 .
install.go:178: [debug] Original chart version: ""
install.go:195: [debug] CHART PATH: /home/ben/Work/github/vector-im/jitsi-helm

---
# Source: jitsi/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
  name: ingress
  namespace: jitsi
  labels:
    scope: jitsi
spec:
  rules:
  - host: "a.b"
    http:
      paths:
      - backend:
          service:
            name: haproxy
            port:
              name: http
        path: /
        pathType: Prefix
  tls:
  - hosts:
    - "a.b"
    secretName: "jitsi-tls"

$ helm template -s templates/ingress.yaml --set "ingress.hosts[0]=a.b" --set JICOFO_AUTH_PASSWORD=a --set JICOFO_COMPONENT_SECRET=b --set JVB_AUTH_PASSWORD=c --debug --set shardCount=1 .
install.go:178: [debug] Original chart version: ""
install.go:195: [debug] CHART PATH: /home/ben/Work/github/vector-im/jitsi-helm

---
# Source: jitsi/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
  name: ingress
  namespace: jitsi
  labels:
    scope: jitsi
spec:
  rules:
  - host: "a.b"
    http:
      paths:
      - backend:
          service:
            name: shard-0-web
            port:
              name: http
        path: /
        pathType: Prefix
  tls:
  - hosts:
    - "a.b"
    secretName: "jitsi-tls"

$ helm template -s templates/haproxy-config.yaml --set "ingress.hosts[0]=a.b" --set JICOFO_AUTH_PASSWORD=a --set JICOFO_COMPONENT_SECRET=b --set JVB_AUTH_PASSWORD=c --debug --set shardCount=1 .
install.go:178: [debug] Original chart version: ""
install.go:195: [debug] CHART PATH: /home/ben/Work/github/vector-im/jitsi-helm

Error: could not find template templates/haproxy-config.yaml in chart
helm.go:84: [debug] could not find template templates/haproxy-config.yaml in chart

$ helm template -s templates/haproxy-config.yaml --set "ingress.hosts[0]=a.b" --set JICOFO_AUTH_PASSWORD=a --set JICOFO_COMPONENT_SECRET=b --set JVB_AUTH_PASSWORD=c --debug --set shardCount=2 .
install.go:178: [debug] Original chart version: ""
install.go:195: [debug] CHART PATH: /home/ben/Work/github/vector-im/jitsi-helm

---
# Source: jitsi/templates/haproxy-config.yaml
apiVersion: v1
data:
  haproxy.cfg: |
....
kind: ConfigMap
metadata:
  name: haproxy-config
  namespace: jitsi
```