### PR TITLE
Add the ability to inject extra labels for the JVB metrics Service

### DIFF
--- a/templates/jvb-services.yaml
+++ b/templates/jvb-services.yaml
@@ -30,11 +30,20 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  {{ if $.Values.jvb.monitoringEnable }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9888"
+    prometheus.io/path: "/metrics"
+  {{ end }}
   labels:
     scope: jitsi
     service: jvb
     shard: {{ $shard | quote }}
     replica: {{ $replica | quote }}
+    {{- if $.Values.jvb.monitoring.service.extraLabels }}
+    {{- $.Values.jvb.monitoring.service.extraLabels | toYaml | nindent 4 }}
+    {{- end }}
   name: shard-{{ $shard }}-{{ $.Values.jvb.name }}-{{ $replica }}-metrics
   namespace: {{ $.Values.namespace }}
 spec:

--- a/values.yaml
+++ b/values.yaml
@@ -47,6 +47,8 @@ jvb:
   imagePullPolicy: Always
   monitoringEnable: true
   monitoring:
+    service:
+      extraLabels: []
     image: systemli/prometheus-jitsi-meet-exporter:1.2.0
     imagePullPolicy: Always
   sysctlDaemonSetEnable: true


### PR DESCRIPTION
This helps us set the appropriate labels for the JVB metrics Service to get scraped by our monitoring stack
Ref https://github.com/matrix-org/matrix-ansible-private/issues/6491