### PR TITLE
JVB: autoset the JVM heap to 95% of limits

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.3
+version: 0.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/templates/jvb-statefulset.yaml
+++ b/templates/jvb-statefulset.yaml
@@ -121,6 +121,10 @@ spec:
               fieldPath: status.podIP
         - name: JVB_ADVERTISE_PRIVATE_CANDIDATES
           value: "false"
+      {{- if ne (merge $.Values dict | dig "jvb" "resources" "limits" "memory" "") "" }}
+        - name: VIDEOBRIDGE_MAX_MEMORY
+          value: {{ mulf (regexFind "[0-9]+" $.Values.jvb.resources.limits.memory) 0.95 }}{{ regexFind "[A-Z]" $.Values.jvb.resources.limits.memory | lower }}
+      {{- end }}
       {{- if $.Values.jvb.extraEnvs }}
         {{- toYaml $.Values.jvb.extraEnvs | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
https://github.com/jitsi/jitsi-videobridge/blob/master/jvb/resources/jvb.sh#L19 sets the JVB max memory to 3GB by default. If we've set limits, lets set the heap to 95% of that instead