### PR TITLE
Better naming/labeling

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/README.md
+++ b/README.md
@@ -57,8 +57,6 @@ The following table lists the configurable parameters of the Jitsi Meet chart an
 | Parameter                          | Description                                             | Default           |
 |------------------------------------|---------------------------------------------------------|-------------------|
 | `shardCount`                       | Number of shards                                        | `2`               |
-| `namespace`                        | Namespace                                               | `jitsi`           |
-| `haproxy.name`                     | Haproxy statefulset name                                | `jitsi/jicofo`    |
 | `haproxy.image`                    | Docker image                                            | `haproxy:2.1`     |
 | `ingress.enabled`                  | Enable ingress                                          | `true`            |
 | `ingress.hosts`                    | List of hosts in this ingress                           | empty             |
@@ -66,11 +64,9 @@ The following table lists the configurable parameters of the Jitsi Meet chart an
 | `ingress.tls.enabled`              | Enable TLS for ingress                                  | `true`            |
 | `ingress.tls.secretName`           | Name of the secret storing the TLS certificate and key  | `jitsi-tls`       |
 | `ingress.extraPaths    `           | Extra paths to add to the ingress                       | `[]`              |
-| `jicofo.name`                      | Jicofo deployment name                                  | `jicofo`          |
 | `jicofo.image`                     | Jicofo docker image                                     | `jitsi/jicofo`    |
 | `jicofo.imagePullPolicy`           | Jicofo image pull policy                                | `Always`          |
 | `jicofo.extraEnvs`                 | Jicofo extra environment variables                      | `[]`              |
-| `jvb.name`                         | JVB statefulset name                                    | `jitsi/jvb`       |
 | `jvb.image`                        | JVB docker image                                        | `jitsi/jvb`       |
 | `jvb.image.imagePullPolicy`        | JVB image pull policy                                   | `Always`          |
 | `jvb.replicas`                     | JVB replica count                                       | `1`               |
@@ -78,7 +74,6 @@ The following table lists the configurable parameters of the Jitsi Meet chart an
 | `jvb.hostPort`                     | JVB hostPort                                            | empty             |
 | `jvb.nodeportPrefix`               | JVB Node port prefix                                    | `30`              |
 | `jvb.extraEnvs`                    | JVB extra environment variables                         | `[]`              |
-| `prosody.name`                     | Prosody deployment name                                 | `jitsi/prosody`   |
 | `prosody.image`                    | Prosody docker image                                    | `jitsi/prosody`   |
 | `prosody.image.imagePullPolicy`    | Prosody image pull policy                               | `Always`          |
 | `prosody.extraEnvs`                | Extra env var for prosody deployment                    | `[]`              |
@@ -86,7 +81,6 @@ The following table lists the configurable parameters of the Jitsi Meet chart an
 | `prosody.extraVolumeMounts`        | Additional volume mounts to the prosody deployment      | `[]`              |
 | `prosody.globalModules`            | Additional global modules to enable on prosody          | `[]`              |
 | `prosody.globalConfig`             | Additional global config parameters on prosody          | `[]`              |
-| `web.name`                         | Web deployment name                                     | `web`             |
 | `web.image`                        | Web docker image                                        | `jitsi/web`       |
 | `web.image.imagePullPolicy`        | Web image pull policy                                   | `Always`          |
 | `web.extraEnvs`                    | Extra env var for web deployment                        | `[]`              |

--- a/configs/haproxy/haproxy.cfg
+++ b/configs/haproxy/haproxy.cfg
@@ -41,12 +41,12 @@ peers mypeers
   bind :1024
   log stdout format raw local0 info
 
-.if streq("${HOSTNAME}",{{ $.Values.haproxy.name }}-0)
-  server {{ $.Values.haproxy.name }}-0
-  server {{ $.Values.haproxy.name }}-1 "{{ print "${" $.Values.haproxy.name | upper }}_1_SERVICE_HOST}:{{ print "${" $.Values.haproxy.name | upper }}_1_SERVICE_PORT}"
+.if streq("${HOSTNAME}",{{ include "jitsi.name" . }}-haproxy-0)
+  server {{ include "jitsi.name" . }}-haproxy-0
+  server {{ include "jitsi.name" . }}-haproxy-1 "{{ print "${" }}{{ include "jitsi.name" $ | upper }}_HAPROXY_1_SERVICE_HOST}:{{ print "${" }}{{ include "jitsi.name" $ | upper }}_HAPROXY_1_SERVICE_PORT}"
 .else
-  server {{ $.Values.haproxy.name }}-0 "{{ print "${" $.Values.haproxy.name | upper}}_0_SERVICE_HOST}:{{ print "${" $.Values.haproxy.name | upper }}_0_SERVICE_PORT}"
-  server {{ $.Values.haproxy.name }}-1
+  server {{ include "jitsi.name" . }}-haproxy-0 "{{ print "${" }}{{ include "jitsi.name" $ | upper }}_HAPROXY_0_SERVICE_HOST}:{{ print "${" }}{{ include "jitsi.name" $ | upper }}_HAPROXY_0_SERVICE_PORT}"
+  server {{ include "jitsi.name" . }}-haproxy-1
 .endif
 
 backend jitsi-meet
@@ -66,5 +66,5 @@ backend jitsi-meet
   # We don't use server-template here so as we want to use k8s to dispatch to an up nginx in the shard
   # If we used server-template we'd have web.replicas * shardCount nginxes
 {{- range $shard, $e := until (int $.Values.shardCount) }}
-  server shard{{ $shard }} shard-{{ $shard }}-{{ $.Values.web.name }}.{{ $.Release.Namespace}}.svc.cluster.local:{{ $.Values.web.httpPort }} check resolvers kube-dns init-addr none
+  server shard{{ $shard }} {{ include "jitsi.name" $ }}-shard-{{ $shard }}-web.{{ $.Release.Namespace }}.svc.cluster.local:{{ $.Values.web.httpPort }} check resolvers kube-dns init-addr none
 {{- end }}

--- a/configs/haproxy/haproxy.cfg
+++ b/configs/haproxy/haproxy.cfg
@@ -66,5 +66,5 @@ backend jitsi-meet
   # We don't use server-template here so as we want to use k8s to dispatch to an up nginx in the shard
   # If we used server-template we'd have web.replicas * shardCount nginxes
 {{- range $shard, $e := until (int $.Values.shardCount) }}
-  server shard{{ $shard }} shard-{{ $shard }}-{{ $.Values.web.name }}.{{ $.Values.namespace}}.svc.cluster.local:{{ $.Values.web.httpPort }} check resolvers kube-dns init-addr none
+  server shard{{ $shard }} shard-{{ $shard }}-{{ $.Values.web.name }}.{{ $.Release.Namespace}}.svc.cluster.local:{{ $.Values.web.httpPort }} check resolvers kube-dns init-addr none
 {{- end }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -191,7 +191,7 @@ app.kubernetes.io/component: jitsi-ingress
 {{/*
 Define a helper function to output the data of the shared ConfigMap
 */}}
-{{- define "jitsi.sharedconfigmap.data" -}}
+{{- define "jitsi.sharedConfigMap.data" -}}
 JVB_STUN_SERVERS: {{ $.Values.JVB_STUN_SERVERS }}
 PUBLIC_URL: {{ ((gt (len $.Values.ingress.hosts) 0) | ternary (print "https://" ($.Values.ingress.hosts | first)) $.Values.PUBLIC_URL) | required "One of PUBLIC_URL or ingress.hosts must be provided" }}
 TZ: {{ $.Values.TZ }}
@@ -200,8 +200,8 @@ TZ: {{ $.Values.TZ }}
 {{/*
 Define a helper function to create a hash of the output of the previous function
 */}}
-{{- define "jitsi.sharedconfigmap.hash" -}}
-{{- $cm := include "jitsi.sharedconfigmap.data" . | sha256sum }}
+{{- define "jitsi.sharedConfigMap.hash" -}}
+{{- $cm := include "jitsi.sharedConfigMap.data" . | sha256sum }}
 {{- printf "%s" (trunc 63 $cm) -}}
 {{- end }}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -13,27 +13,167 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
-Create the jicofo cmp name
-*/}}
-{{- define "jitsi.name-jicofo" -}}
-{{- printf "jicofo" | trunc 63 -}}
-{{- end -}}
-
-{{/*
 Common labels
 */}}
 {{- define "jitsi.labels" -}}
-{{/*
-k8s-app: {{ .Chart.Name }}
-app.kubernetes.io/name: {{ include "jitsi.name" . }}
-*/}}
-scope: {{ .Chart.Name  }}
 helm.sh/chart: {{ include "jitsi.chart" . }}
-app.kubernetes.io/instance: {{ .Chart.Name }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/managed-by: {{ .Values.managedBy | default .Release.Service }}
+app.kubernetes.io/part-of: jitsi-stack
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "jitsi.haproxy.selectorLabels" -}}
+{{ include "jitsi.labels" . }}
+app.kubernetes.io/instance: {{ include "jitsi.name" . }}-haproxy
+app.kubernetes.io/name: jitsi-haproxy
+app.kubernetes.io/component: jitsi-load-balancer
+{{- end -}}
+
+{{- define "jitsi.jicofoShard.selectorLabels" -}}
+{{ include "jitsi.labels" . }}
+app.kubernetes.io/instance: {{ include "jitsi.name" . }}-jicofo
+app.kubernetes.io/name: jitsi-jicofo
+app.kubernetes.io/component: jitsi-conference-manager
+shard: {{ toYaml .RelativeScope | quote }}
+{{- end -}}
+
+{{- define "jitsi.jvbGlobal.selectorLabels" -}}
+{{ include "jitsi.labels" . }}
+app.kubernetes.io/instance: {{ include "jitsi.name" . }}-jvb
+app.kubernetes.io/name: jitsi-jvb
+app.kubernetes.io/component: jitsi-selective-forwarding-unit
+{{- end -}}
+
+{{- define "jitsi.jvbShard.selectorLabels" -}}
+{{ include "jitsi.jvbGlobal.labels" . }}
+shard: {{ toYaml .RelativeScope.shard | quote }}
+{{- end -}}
+
+{{- define "jitsi.jvbReplica.selectorLabels" -}}
+{{ include "jitsi.jvbShard.labels" . }}
+replica: {{ toYaml .RelativeScope.replica | quote }}
+{{- end -}}
+
+{{- define "jitsi.prosodyGlobal.selectorLabels" -}}
+{{ include "jitsi.labels" . }}
+app.kubernetes.io/instance: {{ include "jitsi.name" . }}-prosody
+app.kubernetes.io/name: jitsi-prosody
+app.kubernetes.io/component: jitsi-coordinator
+{{- end -}}
+
+{{- define "jitsi.prosodyShard.selectorLabels" -}}
+{{ include "jitsi.prosodyGlobal.selectorLabels" . }}
+shard: {{ toYaml .RelativeScope | quote }}
+{{- end -}}
+
+{{- define "jitsi.sysctlJvb.selectorLabels" -}}
+{{ include "jitsi.labels" . }}
+app.kubernetes.io/instance: {{ include "jitsi.name" . }}-sysctl-jvb
+app.kubernetes.io/name: jitsi-sysctl-jvb
+app.kubernetes.io/component: jitsi-sysctl-setter
+{{- end -}}
+
+{{- define "jitsi.webShard.selectorLabels" -}}
+{{ include "jitsi.labels" . }}
+app.kubernetes.io/instance: {{ include "jitsi.name" . }}-web
+app.kubernetes.io/name: jitsi-web
+app.kubernetes.io/component: jitsi-web-server
+shard: {{ toYaml .RelativeScope | quote }}
+{{- end -}}
+
+{{- define "jitsi.config.labels" -}}
+{{ include "jitsi.labels" . }}
+app.kubernetes.io/instance: {{ include "jitsi.name" . }}-config
+app.kubernetes.io/name: jitsi-config
+app.kubernetes.io/component: jitsi-shared-config
+{{- with $.Values.sharedConfigMapExtraLabels }}
+{{ toYaml .}}
+{{- end }}
+{{- end -}}
+
+{{- define "jitsi.haproxy.labels" -}}
+{{ include "jitsi.haproxy.selectorLabels" . }}
+{{- with $.Values.haproxy.extraLabels }}
+{{ toYaml .}}
+{{- end }}
+{{- end -}}
+
+{{- define "jitsi.ingress.labels" -}}
+{{ include "jitsi.labels" . }}
+app.kubernetes.io/instance: {{ include "jitsi.name" . }}-ingress
+app.kubernetes.io/name: jitsi-ingress
+app.kubernetes.io/component: jitsi-ingress
+{{- with $.Values.ingress.extraLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "jitsi.jicofoShard.labels" -}}
+{{ include "jitsi.jicofoShard.selectorLabels" . }}
+{{- with $.Values.jicofo.extraLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "jitsi.jvbGlobal.labels" -}}
+{{ include "jitsi.jvbGlobal.selectorLabels" . }}
+{{- with $.Values.jvb.extraLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "jitsi.jvbShard.labels" -}}
+{{ include "jitsi.jvbShard.selectorLabels" . }}
+{{- with $.Values.jvb.extraLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "jitsi.jvbReplica.labels" -}}
+{{ include "jitsi.jvbReplica.selectorLabels" . }}
+{{- with $.Values.jvb.extraLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "jitsi.jvbReplicaMonitoring.labels" -}}
+{{ include "jitsi.jvbReplica.selectorLabels" . }}
+{{- with $.Values.jvb.monitoring.service.extraLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "jitsi.prosodyGlobal.labels" -}}
+{{ include "jitsi.prosodyGlobal.selectorLabels" . }}
+{{- with $.Values.prosody.extraLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "jitsi.prosodyShard.labels" -}}
+{{ include "jitsi.prosodyShard.selectorLabels" . }}
+{{- with $.Values.prosody.extraLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{- define "jitsi.sysctlJvb.labels" -}}
+{{ include "jitsi.sysctlJvb.selectorLabels" . }}
+{{- with $.Values.sysctljvb.extraLabels }}
+{{ toYaml .}}
+{{- end }}
+{{- end -}}
+
+{{- define "jitsi.webShard.labels" -}}
+{{ include "jitsi.webShard.selectorLabels" . }}
+{{- with $.Values.web.extraLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -176,6 +176,18 @@ app.kubernetes.io/component: jitsi-ingress
 {{- end }}
 {{- end -}}
 
+{{- define "jitsi.jvb.entryPointConfigMap.name" -}}
+{{ $.Values.jvb.entryPointConfigMap.name | default (print (include "jitsi.name" .) "-jvb-entrypoint") }}
+{{- end -}}
+
+{{- define "jitsi.jvb.gracefulShutdownConfigMap.name" -}}
+{{ $.Values.jvb.gracefulShutdownConfigMap.name | default (print (include "jitsi.name" .) "-jvb-shutdown") }}
+{{- end -}}
+
+{{- define "jitsi.sharedConfigMap.name" -}}
+{{ $.Values.sharedConfigMapName | default (print (include "jitsi.name" .) "-config") }}
+{{- end -}}
+
 {{/*
 Define a helper function to output the data of the shared ConfigMap
 */}}
@@ -192,3 +204,7 @@ Define a helper function to create a hash of the output of the previous function
 {{- $cm := include "jitsi.sharedconfigmap.data" . | sha256sum }}
 {{- printf "%s" (trunc 63 $cm) -}}
 {{- end }}
+
+{{- define "jitsi.sharedSecret.name" -}}
+{{ $.Values.secretName | default (include "jitsi.name" .) }}
+{{- end -}}

--- a/templates/haproxy-config.yaml
+++ b/templates/haproxy-config.yaml
@@ -5,7 +5,7 @@ data:
     {{ tpl (.Files.Get "configs/haproxy/haproxy.cfg") . | nindent 4 }}
 kind: ConfigMap
 metadata:
-  name: haproxy-config
+  name: {{ include "jitsi.name" $ }}-haproxy-config
   namespace: {{ $.Release.Namespace }}
   labels: {{ include "jitsi.haproxy.labels" $ | nindent 4 }}
 {{ end -}}

--- a/templates/haproxy-config.yaml
+++ b/templates/haproxy-config.yaml
@@ -7,4 +7,5 @@ kind: ConfigMap
 metadata:
   name: haproxy-config
   namespace: {{ $.Release.Namespace }}
+  labels: {{ include "jitsi.haproxy.labels" $ | nindent 4 }}
 {{ end -}}

--- a/templates/haproxy-services.yaml
+++ b/templates/haproxy-services.yaml
@@ -4,10 +4,7 @@ kind: Service
 metadata:
   name: {{ $.Values.haproxy.name }}
   namespace: {{ $.Release.Namespace }}
-  {{- with $.Values.haproxy.extraLabels }}
-  labels:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  labels: {{ include "jitsi.haproxy.labels" $ | nindent 4 }}
 spec:
   ports:
   - name: http
@@ -16,8 +13,7 @@ spec:
   - name: metrics
     port: 9090
     targetPort: metrics
-  selector:
-    k8s-app: {{ $.Values.haproxy.name }}
+  selector: {{ include "jitsi.haproxy.selectorLabels" $ | nindent 6 }}
   type: ClusterIP
 ---
 apiVersion: v1
@@ -25,13 +21,15 @@ kind: Service
 metadata:
   name: {{ $.Values.haproxy.name }}-0
   namespace: {{ $.Release.Namespace }}
+  labels: {{ include "jitsi.haproxy.labels" $ | nindent 4 }}
 spec:
   ports:
   - name: peering
     port: 1024
     targetPort: peering
   selector:
-   statefulset.kubernetes.io/pod-name: {{ $.Values.haproxy.name }}-0
+    statefulset.kubernetes.io/pod-name: {{ $.Values.haproxy.name }}-0
+    {{ include "jitsi.haproxy.labels" $ | nindent 4 }}
   type: ClusterIP
 ---
 apiVersion: v1
@@ -39,12 +37,14 @@ kind: Service
 metadata:
   name: {{ $.Values.haproxy.name }}-1
   namespace: {{ $.Release.Namespace }}
+  labels: {{ include "jitsi.haproxy.labels" $ | nindent 4 }}
 spec:
   ports:
   - name: peering
     port: 1024
     targetPort: peering
   selector:
-   statefulset.kubernetes.io/pod-name: {{ $.Values.haproxy.name }}-1
+    statefulset.kubernetes.io/pod-name: {{ $.Values.haproxy.name }}-1
+    {{ include "jitsi.haproxy.labels" $ | nindent 4 }}
   type: ClusterIP
 {{ end -}}

--- a/templates/haproxy-services.yaml
+++ b/templates/haproxy-services.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $.Values.haproxy.name }}
+  name: {{ include "jitsi.name" $ }}-haproxy
   namespace: {{ $.Release.Namespace }}
   labels: {{ include "jitsi.haproxy.labels" $ | nindent 4 }}
 spec:
@@ -19,7 +19,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $.Values.haproxy.name }}-0
+  name: {{ include "jitsi.name" $ }}-haproxy-0
   namespace: {{ $.Release.Namespace }}
   labels: {{ include "jitsi.haproxy.labels" $ | nindent 4 }}
 spec:
@@ -28,14 +28,14 @@ spec:
     port: 1024
     targetPort: peering
   selector:
-    statefulset.kubernetes.io/pod-name: {{ $.Values.haproxy.name }}-0
+    statefulset.kubernetes.io/pod-name: {{ include "jitsi.name" $ }}-haproxy-0
     {{ include "jitsi.haproxy.labels" $ | nindent 4 }}
   type: ClusterIP
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $.Values.haproxy.name }}-1
+  name: {{ include "jitsi.name" $ }}-haproxy-1
   namespace: {{ $.Release.Namespace }}
   labels: {{ include "jitsi.haproxy.labels" $ | nindent 4 }}
 spec:
@@ -44,7 +44,7 @@ spec:
     port: 1024
     targetPort: peering
   selector:
-    statefulset.kubernetes.io/pod-name: {{ $.Values.haproxy.name }}-1
+    statefulset.kubernetes.io/pod-name: {{ include "jitsi.name" $ }}-haproxy-1
     {{ include "jitsi.haproxy.labels" $ | nindent 4 }}
   type: ClusterIP
 {{ end -}}

--- a/templates/haproxy-statefulset.yaml
+++ b/templates/haproxy-statefulset.yaml
@@ -2,11 +2,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  labels:
-    k8s-app: {{ $.Values.haproxy.name }}
-  {{- with $.Values.haproxy.extraLabels }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  labels: {{ include "jitsi.haproxy.labels" $ | nindent 4 }}
   annotations:
     checksum/config: {{ tpl (.Files.Get "configs/haproxy/haproxy.cfg") . | sha256sum }}
   {{- with $.Values.haproxy.extraAnnotations }}
@@ -17,16 +13,11 @@ metadata:
 spec:
   replicas: 2
   selector:
-    matchLabels:
-      k8s-app: {{ $.Values.haproxy.name }}
+    matchLabels: {{ include "jitsi.haproxy.selectorLabels" $ | nindent 6 }}
   serviceName: {{ $.Values.haproxy.name }}
   template:
     metadata:
-      labels:
-        k8s-app: {{ $.Values.haproxy.name }}
-        {{- with $.Values.haproxy.extraLabels }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
+      labels: {{ include "jitsi.haproxy.labels" $ | nindent 8 }}
       annotations:
         checksum/config: {{ tpl (.Files.Get "configs/haproxy/haproxy.cfg") . | sha256sum }}
       {{- with $.Values.haproxy.extraAnnotations }}
@@ -45,11 +36,7 @@ spec:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
-              matchExpressions:
-              - key: k8s-app
-                operator: In
-                values:
-                - {{ $.Values.haproxy.name }}
+              matchLabels: {{ include "jitsi.haproxy.selectorLabels" $ | nindent 16 }}
             topologyKey: topology.kubernetes.io/zone
       containers:
       - env:

--- a/templates/haproxy-statefulset.yaml
+++ b/templates/haproxy-statefulset.yaml
@@ -8,13 +8,13 @@ metadata:
   {{- with $.Values.haproxy.extraAnnotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  name: {{ $.Values.haproxy.name }}
+  name: {{ include "jitsi.name" $ }}-haproxy
   namespace: {{ $.Release.Namespace }}
 spec:
   replicas: 2
   selector:
     matchLabels: {{ include "jitsi.haproxy.selectorLabels" $ | nindent 6 }}
-  serviceName: {{ $.Values.haproxy.name }}
+  serviceName: {{ include "jitsi.name" $ }}-haproxy
   template:
     metadata:
       labels: {{ include "jitsi.haproxy.labels" $ | nindent 8 }}
@@ -84,7 +84,7 @@ spec:
           items:
           - key: haproxy.cfg
             path: haproxy.cfg
-          name: haproxy-config
+          name: {{ include "jitsi.name" $ }}-haproxy-config
         name: haproxy-config
     {{- with $.Values.haproxy.extraVolumes }}
       {{- toYaml . | nindent 6 }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -12,11 +12,7 @@ metadata:
     {{- end }}
   name:  {{ $.Values.ingress.name }}
   namespace: {{ $.Release.Namespace }}
-  labels:
-    scope: jitsi
-  {{- with $.Values.ingress.extraLabels }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  labels: {{ include "jitsi.ingress.labels" $ | nindent 4 }}
 spec:
   {{ if $.Values.ingress.class -}}
   ingressClassName: {{ $.Values.ingress.class }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- if $.Values.ingress.annotations }}
     {{- $.Values.ingress.annotations | toYaml | nindent 4 }}
     {{- end }}
-  name:  {{ $.Values.ingress.name }}
+  name: {{ include "jitsi.name" . }}
   namespace: {{ $.Release.Namespace }}
   labels: {{ include "jitsi.ingress.labels" $ | nindent 4 }}
 spec:
@@ -37,7 +37,7 @@ spec:
       {{ end -}}
       - backend:
           service:
-            name: {{ if (gt ($.Values.shardCount | int) 1) }}haproxy{{ else }}shard-0-{{ $.Values.web.name }}{{ end }}
+            name: {{ if (gt ($.Values.shardCount | int) 1) }}{{ include "jitsi.name" $ }}-haproxy{{ else }}{{ include "jitsi.name" $ }}-shard-0-web{{ end }}
             port:
               name: http
         path: /

--- a/templates/jicofo-deployment.yaml
+++ b/templates/jicofo-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   {{- with $.Values.jicofo.extraAnnotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  name: shard-{{ $shard }}-{{ $.Values.jicofo.name }}
+  name: {{ include "jitsi.name" $ }}-shard-{{ $shard }}-jicofo
   namespace: {{ $.Release.Namespace }}
 spec:
   replicas: 1
@@ -40,7 +40,7 @@ spec:
       containers:
       - env:
         - name: XMPP_SERVER
-          value: shard-{{ $shard }}-{{ $.Values.prosody.name }}.{{ $.Release.Namespace }}.svc.cluster.local
+          value: {{ include "jitsi.name" $ }}-shard-{{ $shard }}-prosody.{{ $.Release.Namespace }}.svc.cluster.local
         - name: XMPP_DOMAIN
           value: meet.jitsi
         - name: XMPP_AUTH_DOMAIN
@@ -51,19 +51,19 @@ spec:
           valueFrom:
             secretKeyRef:
               key: JICOFO_COMPONENT_SECRET
-              name: {{ $.Values.secretName }}
+              name: {{ include "jitsi.sharedSecret.name" $ }}
         - name: JICOFO_AUTH_USER
           value: focus
         - name: JICOFO_AUTH_PASSWORD
           valueFrom:
             secretKeyRef:
               key: JICOFO_AUTH_PASSWORD
-              name: {{ $.Values.secretName }}
+              name: {{ include "jitsi.sharedSecret.name" $ }}
         - name: TZ
           valueFrom:
             configMapKeyRef:
               key: TZ
-              name: {{ $.Values.sharedConfigMapName }}
+              name: {{ include "jitsi.sharedConfigMap.name" $ }}
         - name: JVB_BREWERY_MUC
           value: jvbbrewery
         - name: JICOFO_ENABLE_HEALTH_CHECKS

--- a/templates/jicofo-deployment.yaml
+++ b/templates/jicofo-deployment.yaml
@@ -3,13 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels:
-    k8s-app: {{ $.Values.jicofo.name }}
-    scope: jitsi
-    shard: {{ $shard | quote}}
-  {{- with $.Values.jicofo.extraLabels }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  labels: {{ include "jitsi.jicofoShard.labels" (merge (dict "RelativeScope" .) $) | nindent 4 }}
   annotations:
     configmap-hash: {{ include "jitsi.sharedconfigmap.hash" $ }}
   {{- with $.Values.jicofo.extraAnnotations }}
@@ -20,10 +14,7 @@ metadata:
 spec:
   replicas: 1
   selector:
-    matchLabels:
-      k8s-app: {{ $.Values.jicofo.name }}
-      scope: jitsi
-      shard: {{ $shard | quote}}
+    matchLabels: {{ include "jitsi.jicofoShard.selectorLabels" (merge (dict "RelativeScope" .) $) | nindent 6 }}
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -31,13 +22,7 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      labels:
-        k8s-app: {{ $.Values.jicofo.name }}
-        scope: jitsi
-        shard: {{ $shard | quote}}
-      {{- with $.Values.jicofo.extraLabels }}
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      labels: {{ include "jitsi.jicofoShard.labels" (merge (dict "RelativeScope" .) $) | nindent 8 }}
       annotations:
         configmap-hash: {{ include "jitsi.sharedconfigmap.hash" $ }}
       {{- with $.Values.jicofo.extraAnnotations }}

--- a/templates/jicofo-deployment.yaml
+++ b/templates/jicofo-deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   labels: {{ include "jitsi.jicofoShard.labels" (merge (dict "RelativeScope" .) $) | nindent 4 }}
   annotations:
-    configmap-hash: {{ include "jitsi.sharedconfigmap.hash" $ }}
+    configmap-hash: {{ include "jitsi.sharedConfigMap.hash" $ }}
   {{- with $.Values.jicofo.extraAnnotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -24,7 +24,7 @@ spec:
     metadata:
       labels: {{ include "jitsi.jicofoShard.labels" (merge (dict "RelativeScope" .) $) | nindent 8 }}
       annotations:
-        configmap-hash: {{ include "jitsi.sharedconfigmap.hash" $ }}
+        configmap-hash: {{ include "jitsi.sharedConfigMap.hash" $ }}
       {{- with $.Values.jicofo.extraAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/templates/jvb-entrypoint.yaml
+++ b/templates/jvb-entrypoint.yaml
@@ -5,11 +5,7 @@ data:
     {{- tpl (.Files.Get "configs/jvb/entrypoint.sh") . | nindent 4 }}
 kind: ConfigMap
 metadata:
-  labels:
-    scope: jitsi
-  {{- with $.Values.jvb.extraLabels }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  labels: {{ include "jitsi.jvbGlobal.labels" $ | nindent 4 }}
   name: {{ $.Values.jvb.entryPointConfigMap.name }}
   namespace: {{ $.Release.Namespace }}
 {{- end }}

--- a/templates/jvb-entrypoint.yaml
+++ b/templates/jvb-entrypoint.yaml
@@ -6,6 +6,6 @@ data:
 kind: ConfigMap
 metadata:
   labels: {{ include "jitsi.jvbGlobal.labels" $ | nindent 4 }}
-  name: {{ $.Values.jvb.entryPointConfigMap.name }}
+  name: {{ include "jitsi.jvb.entryPointConfigMap.name" $ }}
   namespace: {{ $.Release.Namespace }}
 {{- end }}

--- a/templates/jvb-services.yaml
+++ b/templates/jvb-services.yaml
@@ -6,7 +6,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels: {{ include "jitsi.jvbReplica.labels" (merge (dict "RelativeScope" (dict "shard" $shard "replica" $replica)) $) | nindent 4 }}
-  name: shard-{{ $shard }}-{{ $.Values.jvb.name }}-{{ $replica }}-ice
+  name: {{ include "jitsi.name" $ }}-shard-{{ $shard }}-jvb-{{ $replica }}-ice
   namespace: {{ $.Release.Namespace }}
 spec:
   type: NodePort
@@ -18,7 +18,7 @@ spec:
     targetPort: {{ $.Values.jvb.nodeportPrefix }}{{ add $shard 3 }}{{ printf "%02d" $replica }}
     nodePort: {{ $.Values.jvb.nodeportPrefix }}{{ add $shard 3 }}{{ printf "%02d" $replica }}
   selector:
-    statefulset.kubernetes.io/pod-name: shard-{{ $shard }}-{{ $.Values.jvb.name }}-{{ $replica }}
+    statefulset.kubernetes.io/pod-name: {{ include "jitsi.name" $ }}-shard-{{ $shard }}-jvb-{{ $replica }}
     {{ include "jitsi.jvbShard.labels" (merge (dict "RelativeScope" (dict "shard" $shard)) $) | nindent 4 }}
 {{ end -}}
 ---
@@ -30,7 +30,7 @@ metadata:
     {{ toYaml . | nindent 4 }}
 {{ end }}
   labels: {{ include "jitsi.jvbReplicaMonitoring.labels" (merge (dict "RelativeScope" (dict "shard" $shard "replica" $replica)) $) | nindent 4 }}
-  name: shard-{{ $shard }}-{{ $.Values.jvb.name }}-{{ $replica }}-metrics
+  name: {{ include "jitsi.name" $ }}-shard-{{ $shard }}-jvb-{{ $replica }}-metrics
   namespace: {{ $.Release.Namespace }}
 spec:
   type: ClusterIP
@@ -40,7 +40,7 @@ spec:
     port: 9888
     targetPort: metrics
   selector:
-    statefulset.kubernetes.io/pod-name: shard-{{ $shard }}-{{ $.Values.jvb.name }}-{{ $replica }}
+    statefulset.kubernetes.io/pod-name: {{ include "jitsi.name" $ }}-shard-{{ $shard }}-jvb-{{ $replica }}
     {{ include "jitsi.jvbShard.labels" (merge (dict "RelativeScope" (dict "shard" $shard)) $) | nindent 4 }}
 {{ end -}}
 {{ end -}}

--- a/templates/jvb-services.yaml
+++ b/templates/jvb-services.yaml
@@ -5,14 +5,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    scope: jitsi
-    service: jvb
-    shard: {{ $shard | quote }}
-    replica: {{ $replica | quote }}
-  {{- with $.Values.jvb.extraLabels }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  labels: {{ include "jitsi.jvbReplica.labels" (merge (dict "RelativeScope" (dict "shard" $shard "replica" $replica)) $) | nindent 4 }}
   name: shard-{{ $shard }}-{{ $.Values.jvb.name }}-{{ $replica }}-ice
   namespace: {{ $.Release.Namespace }}
 spec:
@@ -26,8 +19,7 @@ spec:
     nodePort: {{ $.Values.jvb.nodeportPrefix }}{{ add $shard 3 }}{{ printf "%02d" $replica }}
   selector:
     statefulset.kubernetes.io/pod-name: shard-{{ $shard }}-{{ $.Values.jvb.name }}-{{ $replica }}
-    scope: jitsi
-    shard: {{ $shard | quote }}
+    {{ include "jitsi.jvbShard.labels" (merge (dict "RelativeScope" (dict "shard" $shard)) $) | nindent 4 }}
 {{ end -}}
 ---
 apiVersion: v1
@@ -37,14 +29,7 @@ metadata:
   annotations:
     {{ toYaml . | nindent 4 }}
 {{ end }}
-  labels:
-    scope: jitsi
-    service: jvb
-    shard: {{ $shard | quote }}
-    replica: {{ $replica | quote }}
-  {{- with $.Values.jvb.monitoring.service.extraLabels }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  labels: {{ include "jitsi.jvbReplicaMonitoring.labels" (merge (dict "RelativeScope" (dict "shard" $shard "replica" $replica)) $) | nindent 4 }}
   name: shard-{{ $shard }}-{{ $.Values.jvb.name }}-{{ $replica }}-metrics
   namespace: {{ $.Release.Namespace }}
 spec:
@@ -56,7 +41,6 @@ spec:
     targetPort: metrics
   selector:
     statefulset.kubernetes.io/pod-name: shard-{{ $shard }}-{{ $.Values.jvb.name }}-{{ $replica }}
-    scope: jitsi
-    shard: {{ $shard | quote }}
+    {{ include "jitsi.jvbShard.labels" (merge (dict "RelativeScope" (dict "shard" $shard)) $) | nindent 4 }}
 {{ end -}}
 {{ end -}}

--- a/templates/jvb-shutdown.yaml
+++ b/templates/jvb-shutdown.yaml
@@ -5,11 +5,7 @@ data:
     {{- .Files.Get "configs/jvb/graceful_shutdown.sh" | nindent 4 }}
 kind: ConfigMap
 metadata:
-  labels:
-    scope: jitsi
-  {{- with $.Values.jvb.extraLabels }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  labels: {{ include "jitsi.jvbGlobal.labels" $ | nindent 4 }}
   name: {{ $.Values.jvb.gracefulShutdownConfigMap.name }}
   namespace: {{ $.Release.Namespace }}
 {{- end }}

--- a/templates/jvb-shutdown.yaml
+++ b/templates/jvb-shutdown.yaml
@@ -6,6 +6,6 @@ data:
 kind: ConfigMap
 metadata:
   labels: {{ include "jitsi.jvbGlobal.labels" $ | nindent 4 }}
-  name: {{ $.Values.jvb.gracefulShutdownConfigMap.name }}
+  name: {{ include "jitsi.jvb.gracefulShutdownConfigMap.name" $ }}
   namespace: {{ $.Release.Namespace }}
 {{- end }}

--- a/templates/jvb-statefulset.yaml
+++ b/templates/jvb-statefulset.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- with $.Values.jvb.extraAnnotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  name: shard-{{ $shard }}-{{ $.Values.jvb.name }}
+  name: {{ include "jitsi.name" $ }}-shard-{{ $shard }}-jvb
   namespace: {{ $.Release.Namespace }}
 spec:
   podManagementPolicy: Parallel
@@ -80,7 +80,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: XMPP_SERVER
-          value: shard-{{ $shard }}-{{ $.Values.prosody.name }}.{{ $.Release.Namespace }}.svc.cluster.local
+          value: {{ include "jitsi.name" $ }}-shard-{{ $shard }}-prosody.{{ $.Release.Namespace }}.svc.cluster.local
       {{- if $.Values.jvb.provideNodeAddressAsPublicIP }}
         - name: DOCKER_HOST_ADDRESS
           valueFrom:
@@ -104,7 +104,7 @@ spec:
           valueFrom:
             configMapKeyRef:
               key: JVB_STUN_SERVERS
-              name: {{ $.Values.sharedConfigMapName }}
+              name: {{ include "jitsi.sharedConfigMap.name" $ }}
         - name: COLIBRI_REST_ENABLED
           value: "true"
         - name: SHUTDOWN_REST_ENABLED
@@ -115,18 +115,18 @@ spec:
           valueFrom:
             secretKeyRef:
               key: JVB_AUTH_PASSWORD
-              name: {{ $.Values.secretName }}
+              name: {{ include "jitsi.sharedSecret.name" $ }}
         - name: JVB_BREWERY_MUC
           value: jvbbrewery
         - name: TZ
           valueFrom:
             configMapKeyRef:
               key: TZ
-              name: {{ $.Values.sharedConfigMapName }}
+              name: {{ include "jitsi.sharedConfigMap.name" $ }}
         - name: PUBLIC_URL
           valueFrom:
             configMapKeyRef:
-              name: {{ $.Values.sharedConfigMapName }}
+              name: {{ include "jitsi.sharedConfigMap.name" $ }}
               key: PUBLIC_URL
         - name: JVB_WS_SERVER_ID
           valueFrom:
@@ -212,13 +212,13 @@ spec:
       volumes:
       - configMap:
           defaultMode: 508
-          name: {{ $.Values.jvb.entryPointConfigMap.name }}
+          name: {{ include "jitsi.jvb.entryPointConfigMap.name" $ }}
         name: jvb-entrypoint
     {{- end }}
     {{- if $.Values.jvb.gracefulShutdownConfigMap.enable }}
       - configMap:
           defaultMode: 508
-          name: {{ $.Values.jvb.gracefulShutdownConfigMap.name }}
+          name: {{ include "jitsi.jvb.gracefulShutdownConfigMap.name" $ }}
         name: jvb-shutdown
     {{- end }}
     {{- with $.Values.jvb.extraVolumes }}

--- a/templates/jvb-statefulset.yaml
+++ b/templates/jvb-statefulset.yaml
@@ -4,13 +4,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  labels:
-    k8s-app: {{ $.Values.jvb.name }}
-    scope: jitsi
-    shard: {{ $shard | quote }}
-  {{- with $.Values.jvb.extraLabels }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  labels: {{ include "jitsi.jvbShard.labels" (merge (dict "RelativeScope" (dict "shard" $shard)) $) | nindent 4 }}
   annotations:
     configmap-hash: {{ include "jitsi.sharedconfigmap.hash" $ }}
   {{- with $.Values.jvb.extraAnnotations }}
@@ -22,20 +16,11 @@ spec:
   podManagementPolicy: Parallel
   replicas: {{ $.Values.jvb.replicas }}
   selector:
-    matchLabels:
-      k8s-app: {{ $.Values.jvb.name }}
-      scope: jitsi
-      shard: {{ $shard | quote }}
+    matchLabels: {{ include "jitsi.jvbShard.selectorLabels" (merge (dict "RelativeScope" (dict "shard" $shard)) $) | nindent 6 }}
   serviceName: jvb
   template:
     metadata:
-      labels:
-        k8s-app: {{ $.Values.jvb.name }}
-        scope: jitsi
-        shard: {{ $shard | quote }}
-      {{- with $.Values.jvb.extraLabels }}
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      labels: {{ include "jitsi.jvbShard.labels" (merge (dict "RelativeScope" (dict "shard" $shard)) $) | nindent 8 }}
       annotations:
         configmap-hash: {{ include "jitsi.sharedconfigmap.hash" $ }}
         kubectl.kubernetes.io/default-container: jvb

--- a/templates/jvb-statefulset.yaml
+++ b/templates/jvb-statefulset.yaml
@@ -6,7 +6,7 @@ kind: StatefulSet
 metadata:
   labels: {{ include "jitsi.jvbShard.labels" (merge (dict "RelativeScope" (dict "shard" $shard)) $) | nindent 4 }}
   annotations:
-    configmap-hash: {{ include "jitsi.sharedconfigmap.hash" $ }}
+    configmap-hash: {{ include "jitsi.sharedConfigMap.hash" $ }}
   {{- with $.Values.jvb.extraAnnotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -22,7 +22,7 @@ spec:
     metadata:
       labels: {{ include "jitsi.jvbShard.labels" (merge (dict "RelativeScope" (dict "shard" $shard)) $) | nindent 8 }}
       annotations:
-        configmap-hash: {{ include "jitsi.sharedconfigmap.hash" $ }}
+        configmap-hash: {{ include "jitsi.sharedConfigMap.hash" $ }}
         kubectl.kubernetes.io/default-container: jvb
       {{ if $.Values.jvb.monitoringEnable }}
         prometheus.io/scrape: "true"

--- a/templates/prosody-config.yaml
+++ b/templates/prosody-config.yaml
@@ -8,10 +8,6 @@ data:
     {{- .Files.Get "configs/prosody/mod_prometheus.lua" | nindent 4 }}
 kind: ConfigMap
 metadata:
-  labels:
-    scope: jitsi
-  {{- with $.Values.prosody.extraLabels }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  labels: {{ include "jitsi.prosodyGlobal.labels" $ | nindent 4 }}
   name: {{ $.Values.prosody.configMap.name }}
   namespace: {{ $.Release.Namespace }}

--- a/templates/prosody-config.yaml
+++ b/templates/prosody-config.yaml
@@ -9,5 +9,5 @@ data:
 kind: ConfigMap
 metadata:
   labels: {{ include "jitsi.prosodyGlobal.labels" $ | nindent 4 }}
-  name: {{ $.Values.prosody.configMap.name }}
+  name: {{ include "jitsi.name" $ }}-prosody-config
   namespace: {{ $.Release.Namespace }}

--- a/templates/prosody-deployment.yaml
+++ b/templates/prosody-deployment.yaml
@@ -3,13 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels:
-    k8s-app: {{ $.Values.prosody.name }}
-    scope: jitsi
-    shard: {{ $shard | quote}}
-  {{- with $.Values.prosody.extraLabels }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  labels: {{ include "jitsi.prosodyShard.labels" (merge (dict "RelativeScope" .) $) | nindent 4 }}
   annotations:
     configmap-hash: {{ include "jitsi.sharedconfigmap.hash" $ }}
   {{- with $.Values.prosody.extraAnnotations }}
@@ -20,10 +14,7 @@ metadata:
 spec:
   replicas: 1
   selector:
-    matchLabels:
-      k8s-app: {{ $.Values.prosody.name }}
-      scope: jitsi
-      shard: {{ $shard | quote}}
+    matchLabels: {{ include "jitsi.prosodyShard.selectorLabels" (merge (dict "RelativeScope" .) $) | nindent 6 }}
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -31,13 +22,7 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      labels:
-        k8s-app: {{ $.Values.prosody.name }}
-        scope: jitsi
-        shard: {{ $shard | quote}}
-      {{- with $.Values.prosody.extraLabels }}
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      labels: {{ include "jitsi.prosodyShard.labels" (merge (dict "RelativeScope" .) $) | nindent 8 }}
       annotations:
         configmap-hash: {{ include "jitsi.sharedconfigmap.hash" $ }}
       {{ if $.Values.prosody.monitoringEnable  }}

--- a/templates/prosody-deployment.yaml
+++ b/templates/prosody-deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   labels: {{ include "jitsi.prosodyShard.labels" (merge (dict "RelativeScope" .) $) | nindent 4 }}
   annotations:
-    configmap-hash: {{ include "jitsi.sharedconfigmap.hash" $ }}
+    configmap-hash: {{ include "jitsi.sharedConfigMap.hash" $ }}
   {{- with $.Values.prosody.extraAnnotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -24,7 +24,7 @@ spec:
     metadata:
       labels: {{ include "jitsi.prosodyShard.labels" (merge (dict "RelativeScope" .) $) | nindent 8 }}
       annotations:
-        configmap-hash: {{ include "jitsi.sharedconfigmap.hash" $ }}
+        configmap-hash: {{ include "jitsi.sharedConfigMap.hash" $ }}
       {{ if $.Values.prosody.monitoringEnable  }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "5280"

--- a/templates/prosody-deployment.yaml
+++ b/templates/prosody-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   {{- with $.Values.prosody.extraAnnotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  name: shard-{{ $shard }}-{{ $.Values.prosody.name }}
+  name: {{ include "jitsi.name" $ }}-shard-{{ $shard }}-prosody
   namespace: {{ $.Release.Namespace }}
 spec:
   replicas: 1
@@ -44,7 +44,7 @@ spec:
       volumes:
         - name: prosody
           configMap:
-            name: {{ $.Values.prosody.configMap.name }}
+            name: {{ include "jitsi.name" $ }}-prosody-config
             items:
               - key: mod_prometheus.lua
                 path: mod_prometheus.lua
@@ -132,26 +132,26 @@ spec:
             - name: JICOFO_COMPONENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ $.Values.secretName }}
+                  name: {{ include "jitsi.sharedSecret.name" $ }}
                   key: JICOFO_COMPONENT_SECRET
             - name: JVB_AUTH_USER
               value: jvb
             - name: JVB_AUTH_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ $.Values.secretName }}
+                  name: {{ include "jitsi.sharedSecret.name" $ }}
                   key: JVB_AUTH_PASSWORD
             - name: JICOFO_AUTH_USER
               value: focus
             - name: JICOFO_AUTH_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ $.Values.secretName }}
+                  name: {{ include "jitsi.sharedSecret.name" $ }}
                   key: JICOFO_AUTH_PASSWORD
             - name: TZ
               valueFrom:
                 configMapKeyRef:
-                  name: {{ $.Values.sharedConfigMapName }}
+                  name: {{ include "jitsi.sharedConfigMap.name" $ }}
                   key: TZ
             {{ if $.Values.prosody.monitoringEnable }}
             # activate add-ons that enrich the available stats of prosody
@@ -173,7 +173,7 @@ spec:
             - name: PUBLIC_URL
               valueFrom:
                 configMapKeyRef:
-                  name: {{ $.Values.sharedConfigMapName }}
+                  name: {{ include "jitsi.sharedConfigMap.name" $ }}
                   key: PUBLIC_URL
           {{- if $.Values.prosody.extraEnvs }}
             {{- toYaml $.Values.prosody.extraEnvs | nindent 12 }}

--- a/templates/prosody-svc.yaml
+++ b/templates/prosody-svc.yaml
@@ -3,13 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    scope: jitsi
-    service: {{ $.Values.prosody.name }}
-    shard: {{ $shard | quote}}
-  {{- with $.Values.prosody.extraLabels }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  labels: {{ include "jitsi.prosodyShard.labels" (merge (dict "RelativeScope" .) $) | nindent 4 }}
   name: shard-{{ $shard }}-{{ $.Values.prosody.name }}
   namespace: {{ $.Release.Namespace }}
 spec:
@@ -20,8 +14,5 @@ spec:
   - name: http
     port: 5280
     targetPort: http
-  selector:
-    k8s-app: {{ $.Values.prosody.name }}
-    scope: jitsi
-    shard: {{ $shard | quote}}
+  selector: {{ include "jitsi.prosodyShard.selectorLabels" (merge (dict "RelativeScope" .) $) | nindent 4 }}
 {{ end }}

--- a/templates/prosody-svc.yaml
+++ b/templates/prosody-svc.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels: {{ include "jitsi.prosodyShard.labels" (merge (dict "RelativeScope" .) $) | nindent 4 }}
-  name: shard-{{ $shard }}-{{ $.Values.prosody.name }}
+  name: {{ include "jitsi.name" $ }}-shard-{{ $shard }}-prosody
   namespace: {{ $.Release.Namespace }}
 spec:
   ports:

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -6,8 +6,7 @@ data:
   JVB_AUTH_PASSWORD: {{ required "JVB_AUTH_PASSWORD is required" $.Values.JVB_AUTH_PASSWORD | b64enc }}
 kind: Secret
 metadata:
-  labels:
-    scope: jitsi
+  labels: {{ include "jitsi.labels" $ | nindent 4 }}
   name: {{ $.Values.secretName }}
   namespace: {{ $.Release.Namespace }}
 type: Opaque

--- a/templates/secrets.yaml
+++ b/templates/secrets.yaml
@@ -7,7 +7,7 @@ data:
 kind: Secret
 metadata:
   labels: {{ include "jitsi.labels" $ | nindent 4 }}
-  name: {{ $.Values.secretName }}
+  name: {{ include "jitsi.sharedConfigMap.name" $ }}
   namespace: {{ $.Release.Namespace }}
 type: Opaque
 {{- end }}

--- a/templates/shared-config.yaml
+++ b/templates/shared-config.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  {{ include "jitsi.sharedconfigmap.data" $ | nindent 2 }}
+  {{ include "jitsi.sharedConfigMap.data" $ | nindent 2 }}
 kind: ConfigMap
 metadata:
   labels: {{ include "jitsi.config.labels" $ | nindent 4 }}

--- a/templates/shared-config.yaml
+++ b/templates/shared-config.yaml
@@ -3,10 +3,6 @@ data:
   {{ include "jitsi.sharedconfigmap.data" $ | nindent 2 }}
 kind: ConfigMap
 metadata:
-  labels:
-    scope: jitsi
-  {{- with $.Values.sharedConfigMapExtraLabels }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  labels: {{ include "jitsi.config.labels" $ | nindent 4 }}
   name: {{ $.Values.sharedConfigMapName }}
   namespace: {{ $.Release.Namespace }}

--- a/templates/shared-config.yaml
+++ b/templates/shared-config.yaml
@@ -4,5 +4,5 @@ data:
 kind: ConfigMap
 metadata:
   labels: {{ include "jitsi.config.labels" $ | nindent 4 }}
-  name: {{ $.Values.sharedConfigMapName }}
+  name: {{ include "jitsi.sharedConfigMap.name" $ }}
   namespace: {{ $.Release.Namespace }}

--- a/templates/sysctl-jvb-daemonset.yaml
+++ b/templates/sysctl-jvb-daemonset.yaml
@@ -7,7 +7,7 @@ kind: DaemonSet
 metadata:
   labels: {{ include "jitsi.sysctlJvb.labels" $ | nindent 4 }}
   annotations:
-    configmap-hash: {{ include "jitsi.sharedconfigmap.hash" $ }}
+    configmap-hash: {{ include "jitsi.sharedConfigMap.hash" $ }}
   {{- with $.Values.sysctljvb.extraAnnotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -22,8 +22,9 @@ spec:
     {{- with $.Values.sysctljvb.extraLabels }}
       {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with $.Values.sysctljvb.extraAnnotations }}
       annotations:
+        configmap-hash: {{ include "jitsi.sharedConfigMap.hash" $ }}
+    {{- with $.Values.sysctljvb.extraAnnotations }}
         {{- toYaml . | nindent 8 }}
     {{- end }}
     spec:

--- a/templates/sysctl-jvb-daemonset.yaml
+++ b/templates/sysctl-jvb-daemonset.yaml
@@ -5,12 +5,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  labels:
-    k8s-app: sysctl-jvb
-    scope: jitsi
-    {{- with $.Values.sysctljvb.extraLabels }}
-      {{- toYaml . | nindent 6 }}
-    {{- end }}
+  labels: {{ include "jitsi.sysctlJvb.labels" $ | nindent 4 }}
   annotations:
     configmap-hash: {{ include "jitsi.sharedconfigmap.hash" $ }}
   {{- with $.Values.sysctljvb.extraAnnotations }}
@@ -20,14 +15,10 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 spec:
   selector:
-    matchLabels:
-      k8s-app: sysctl-jvb
-      scope: jitsi
+    matchLabels: {{ include "jitsi.sysctlJvb.labels" $ | nindent 6 }}
   template:
     metadata:
-      labels:
-        k8s-app: sysctl-jvb
-        scope: jitsi
+      labels: {{ include "jitsi.sysctlJvb.labels" $ | nindent 8 }}
     {{- with $.Values.sysctljvb.extraLabels }}
       {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/templates/sysctl-jvb-daemonset.yaml
+++ b/templates/sysctl-jvb-daemonset.yaml
@@ -11,7 +11,7 @@ metadata:
   {{- with $.Values.sysctljvb.extraAnnotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  name: sysctl-jvb
+  name: {{ include "jitsi.name" . }}-sysctl-jvb
   namespace: {{ $.Release.Namespace }}
 spec:
   selector:

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   labels: {{ include "jitsi.webShard.labels" (merge (dict "RelativeScope" .) $) | nindent 4 }}
   annotations:
-    configmap-hash: {{ include "jitsi.sharedconfigmap.hash" $ }}
+    configmap-hash: {{ include "jitsi.sharedConfigMap.hash" $ }}
   {{- with $.Values.web.extraAnnotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -24,7 +24,7 @@ spec:
     metadata:
       labels: {{ include "jitsi.webShard.labels" (merge (dict "RelativeScope" .) $) | nindent 8 }}
       annotations:
-        configmap-hash: {{ include "jitsi.sharedconfigmap.hash" $ }}
+        configmap-hash: {{ include "jitsi.sharedConfigMap.hash" $ }}
       {{- with $.Values.web.extraAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   {{- with $.Values.web.extraAnnotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  name: shard-{{ $shard }}-{{ $.Values.web.name }}
+  name: {{ include "jitsi.name" $ }}-shard-{{ $shard }}-web
   namespace: {{ $.Release.Namespace }}
 spec:
   replicas: {{ $.Values.web.replicas }}
@@ -45,7 +45,7 @@ spec:
         - name: HTTP_PORT
           value: "{{ $.Values.web.httpPort }}"
         - name: XMPP_SERVER
-          value: shard-{{ $shard }}-{{ $.Values.prosody.name }}.{{ $.Release.Namespace }}.svc.cluster.local
+          value: {{ include "jitsi.name" $ }}-shard-{{ $shard }}-prosody.{{ $.Release.Namespace }}.svc.cluster.local
         - name: JICOFO_AUTH_USER
           value: focus
         - name: XMPP_DOMAIN
@@ -55,18 +55,18 @@ spec:
         - name: XMPP_INTERNAL_MUC_DOMAIN
           value: internal-muc.meet.jitsi
         - name: XMPP_BOSH_URL_BASE
-          value: http://shard-{{ $shard }}-{{ $.Values.prosody.name }}.{{ $.Release.Namespace }}.svc.cluster.local:5280
+          value: http://{{ include "jitsi.name" $ }}-shard-{{ $shard }}-prosody.{{ $.Release.Namespace }}.svc.cluster.local:5280
         - name: XMPP_MUC_DOMAIN
           value: muc.meet.jitsi
         - name: TZ
           valueFrom:
             configMapKeyRef:
               key: TZ
-              name: {{ $.Values.sharedConfigMapName }}
+              name: {{ include "jitsi.sharedConfigMap.name" $ }}
         - name: PUBLIC_URL
           valueFrom:
             configMapKeyRef:
-              name: {{ $.Values.sharedConfigMapName }}
+              name: {{ include "jitsi.sharedConfigMap.name" $ }}
               key: PUBLIC_URL
       {{- if $.Values.web.extraEnvs }}
         {{- toYaml $.Values.web.extraEnvs | nindent 8 }}

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -3,13 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels:
-    k8s-app: {{ $.Values.web.name }}
-    scope: jitsi
-    shard: {{ $shard | quote}}
-  {{- with $.Values.web.extraLabels }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  labels: {{ include "jitsi.webShard.labels" (merge (dict "RelativeScope" .) $) | nindent 4 }}
   annotations:
     configmap-hash: {{ include "jitsi.sharedconfigmap.hash" $ }}
   {{- with $.Values.web.extraAnnotations }}
@@ -20,10 +14,7 @@ metadata:
 spec:
   replicas: {{ $.Values.web.replicas }}
   selector:
-    matchLabels:
-      k8s-app: {{ $.Values.web.name }}
-      scope: jitsi
-      shard: {{ $shard | quote}}
+    matchLabels: {{ include "jitsi.webShard.selectorLabels" (merge (dict "RelativeScope" .) $) | nindent 8 }}
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -31,13 +22,7 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      labels:
-        k8s-app: {{ $.Values.web.name }}
-        scope: jitsi
-        shard: {{ $shard | quote}}
-      {{- with $.Values.web.extraLabels }}
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      labels: {{ include "jitsi.webShard.labels" (merge (dict "RelativeScope" .) $) | nindent 8 }}
       annotations:
         configmap-hash: {{ include "jitsi.sharedconfigmap.hash" $ }}
       {{- with $.Values.web.extraAnnotations }}

--- a/templates/web-service.yaml
+++ b/templates/web-service.yaml
@@ -3,13 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    scope: jitsi
-    service: {{ $.Values.web.name }}
-    shard: {{ $shard | quote}}
-  {{- with $.Values.web.extraLabels }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  labels: {{ include "jitsi.webShard.labels" (merge (dict "RelativeScope" .) $) | nindent 4 }}
   name: shard-{{ $shard }}-{{ $.Values.web.name }}
   namespace: {{ $.Release.Namespace }}
 spec:
@@ -17,8 +11,5 @@ spec:
   - name: http
     port: {{ $.Values.web.httpPort }}
     targetPort: http
-  selector:
-    k8s-app: {{ $.Values.web.name }}
-    scope: jitsi
-    shard: {{ $shard | quote}}
+  selector: {{ include "jitsi.webShard.selectorLabels" (merge (dict "RelativeScope" .) $) | nindent 4 }}
 {{- end }}

--- a/templates/web-service.yaml
+++ b/templates/web-service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels: {{ include "jitsi.webShard.labels" (merge (dict "RelativeScope" .) $) | nindent 4 }}
-  name: shard-{{ $shard }}-{{ $.Values.web.name }}
+  name: {{ include "jitsi.name" $ }}-shard-{{ $shard }}-web
   namespace: {{ $.Release.Namespace }}
 spec:
   ports:

--- a/values.yaml
+++ b/values.yaml
@@ -19,11 +19,13 @@ ingress:
     # certManagerClusterIssuer
   annotations: {}
   extraPaths: []
+  extraLabels: {}
 
 haproxy:
   name: haproxy
   image: haproxy:2.4
   extraPodSpec: {}
+  extraLabels: {}
 jicofo:
   name: jicofo
   imagePullPolicy: Always

--- a/values.yaml
+++ b/values.yaml
@@ -6,11 +6,9 @@ global:
   # serviceAccount: "default"
 
 shardCount: 1
-secretName: jitsi-secrets
 
 ingress:
   enabled: true
-  name: ingress
   hosts: []
   # class:
   tls:
@@ -22,12 +20,10 @@ ingress:
   extraLabels: {}
 
 haproxy:
-  name: haproxy
   image: haproxy:2.4
   extraPodSpec: {}
   extraLabels: {}
 jicofo:
-  name: jicofo
   imagePullPolicy: Always
   resources:
     requests:
@@ -41,7 +37,6 @@ jicofo:
   extraVolumes: []
   extraVolumeMounts: []
 jvb:
-  name: jvb
   replicas: 2
   # Specify hostPort to use hostPort and not nodePort
   # Nodeports 30XXX will be used by default
@@ -88,11 +83,11 @@ jvb:
   entryPointConfigMap:
     enable: true
     create: true
-    name: jvb-entrypoint
+    # name - will have `-jvb-entrypoint` as the suffix on the common prefix (Chart Name if no nameOverride set)
   gracefulShutdownConfigMap:
     enable: true
     create: true
-    name: jvb-shutdown
+    # name - will have `-jvb-shutdown` as the suffix on the common prefix (Chart Name if no nameOverride set)
   # change to /usr/bin/graceful_shutdown if using  matrix.org/docker-jitsi-meet openshift images
   shutdownScriptPath: "/shutdown/graceful_shutdown.sh"
   extraEnvs: []
@@ -101,15 +96,12 @@ jvb:
   extraLabels: {}
   extraAnnotations: {}
 prosody:
-  name: prosody
   imagePullPolicy: Always
   monitoringEnable: true
   resources:
     requests:
       memory: 300Mi
       cpu: 300m
-  configMap:
-    name: prosody
   extraEnvs: []
   extraPodSpec: {}
   extraVolumes: []
@@ -120,7 +112,6 @@ prosody:
   extraLabels: {}
   extraAnnotations: {}
 web:
-  name: web
   replicas: 2
   imagePullPolicy: Always
   ## kubectl create configmap -n <namespace> custom-config --from-file=custom-config.js


### PR DESCRIPTION
This PR:
* Fixes some leftover `Values.namespace`, should always be `Release.namespace`
* Fixes up some name issues with the HAProxy manifests after recent PRs
* Sets the [recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/) here rather than relying on them being passed into `extraLabels` for each component
* Consistently sets labels between the top-level labels, the pod template labels and all other components
* Removes `k8s-app` label as it is no longer recommended
* Removes the various `Values.<component>.name` settings. This is not the most natural Helm construct. The Helm [template project](https://github.com/helm/helm/blob/e007c900ce5f2233c8583565d5ba1b0433b1a213/pkg/chartutil/create.go#L429-L431) uses a `<chart>.name` include that defaults the prefix of all resources to `Chart.name` but allows it to be overridden with `Values.nameOverride`. Take the same approach here