### PR TITLE
Fix HAProxy antiAffinity topologyKey to be host rather than zone and add web anti-affinity

### DIFF
--- a/templates/haproxy-statefulset.yaml
+++ b/templates/haproxy-statefulset.yaml
@@ -37,7 +37,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchLabels: {{ include "jitsi.haproxy.selectorLabels" $ | nindent 16 }}
-            topologyKey: topology.kubernetes.io/zone
+            topologyKey: kubernetes.io/hostname
     {{- if $.Values.haproxy.imagePullSecrets }}
       imagePullSecrets:
       {{- range $secretName := $.Values.haproxy.imagePullSecrets }}

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -44,6 +44,14 @@ spec:
       - name: {{ $secretName }}
       {{- end }}
     {{- end }}
+    {{- if gt ($.Values.web.replicas | int) 1 }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels: {{ include "jitsi.webShard.selectorLabels" (merge (dict "RelativeScope" .) $) | nindent 16 }}
+            topologyKey: kubernetes.io/hostname
+    {{- end }}
       containers:
       - env:
         - name: DISABLE_HTTPS


### PR DESCRIPTION
We might want to make this configurable in future but for now do host rather than zone as a) not everything has zones and if we don't have the zone label this doesn't apply, b) we mainly care about the replicas being distributed across hosts