### PR TITLE
Switch runners to cpu-s

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint-test:
-    runs-on: non-dind
+    runs-on: cpu-s
     container: ubuntu
     steps:
       - name: Configure deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
     permissions:
       contents: write
-    runs-on: non-dind
+    runs-on: cpu-s
     container: ubuntu
     steps:
 


### PR DESCRIPTION
Part of https://github.com/vector-im/sre-internal/issues/2778.

`cpu-s` should be enough. If not, we can switch to `cpu-m`, which should suffice.