### PR TITLE
Add OCTO support

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.2
+version: 0.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/templates/jicofo-deployment.yaml
+++ b/templates/jicofo-deployment.yaml
@@ -74,6 +74,12 @@ spec:
           value: jvbbrewery
         - name: JICOFO_ENABLE_HEALTH_CHECKS
           value: "true"
+      {{- if $.Values.octo.enabled }}
+        - name: ENABLE_OCTO
+          value: "true"
+        - name: OCTO_BRIDGE_SELECTION_STRATEGY
+          value: "RegionBasedBridgeSelectionStrategy"
+      {{- end }}
       {{- if $.Values.jicofo.extraEnvs }}
         {{- toYaml $.Values.jicofo.extraEnvs | nindent 8 }}
       {{- end }}

--- a/templates/jvb-statefulset.yaml
+++ b/templates/jvb-statefulset.yaml
@@ -152,6 +152,20 @@ spec:
         - name: VIDEOBRIDGE_MAX_MEMORY
           value: {{ $heapSize }}M
       {{- end }}
+      {{- if $.Values.octo.enabled }}
+        - name: ENABLE_OCTO
+          value: "true"
+        - name: JVB_OCTO_REGION
+          value: {{ $.Values.octo.region | default "all" | quote }}
+        - name: JVB_OCTO_BIND_ADDRESS
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: JVB_OCTO_RELAY_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+      {{- end }}
       {{- if $.Values.jvb.extraEnvs }}
         {{- toYaml $.Values.jvb.extraEnvs | nindent 8 }}
       {{- end }}

--- a/templates/web-deployment.yaml
+++ b/templates/web-deployment.yaml
@@ -82,6 +82,12 @@ spec:
             configMapKeyRef:
               name: {{ include "jitsi.sharedConfigMap.name" $ }}
               key: PUBLIC_URL
+      {{- if $.Values.octo.enabled }}
+        - name: ENABLE_OCTO
+          value: "true"
+        - name: DEPLOYMENTINFO_REGION
+          value: {{ $.Values.octo.region | default "all" | quote }}
+      {{- end }}
       {{- if $.Values.web.extraEnvs }}
         {{- toYaml $.Values.web.extraEnvs | nindent 8 }}
       {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -176,6 +176,9 @@ sysctljvb:
   extraContainerSpec: {}
   extraLabels: {}
   extraAnnotations: {}
+octo:
+  enabled: false
+  region: "all"
 
 createSecret: true
 JICOFO_AUTH_PASSWORD: ""


### PR DESCRIPTION
This PR adds OCTO support.

OCTO allows to host a single meeting across multiple JVBs. So, it is possible to create large meeting depending on the number of JVBs. Recommended max participants in a single meeting with OCTO is 500.

It is disabled by default.